### PR TITLE
[feat/design] globalStyle.css 추가

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-scripts": "5.0.1",
+                "styled-components": "^5.3.6",
                 "web-vitals": "^2.1.4"
             }
         },
@@ -2134,6 +2135,29 @@
                 "postcss": "^8.2",
                 "postcss-selector-parser": "^6.0.10"
             }
+        },
+        "node_modules/@emotion/is-prop-valid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+            "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+            "dependencies": {
+                "@emotion/memoize": "^0.8.0"
+            }
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+            "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+        },
+        "node_modules/@emotion/stylis": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+            "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
         },
         "node_modules/@eslint/eslintrc": {
             "version": "1.4.1",
@@ -5198,6 +5222,26 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/babel-plugin-styled-components": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+            "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.16.0",
+                "@babel/helper-module-imports": "^7.16.0",
+                "babel-plugin-syntax-jsx": "^6.18.0",
+                "lodash": "^4.17.11",
+                "picomatch": "^2.3.0"
+            },
+            "peerDependencies": {
+                "styled-components": ">= 2"
+            }
+        },
+        "node_modules/babel-plugin-syntax-jsx": {
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+            "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+        },
         "node_modules/babel-plugin-transform-react-remove-prop-types": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
@@ -5509,6 +5553,14 @@
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/camelize": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/caniuse-api": {
@@ -5942,6 +5994,14 @@
                 "postcss": "^8.4"
             }
         },
+        "node_modules/css-color-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/css-declaration-sorter": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
@@ -6122,6 +6182,16 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
             "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+        },
+        "node_modules/css-to-react-native": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+            "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+            "dependencies": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
+            }
         },
         "node_modules/css-tree": {
             "version": "1.0.0-alpha.37",
@@ -8568,6 +8638,19 @@
             "bin": {
                 "he": "bin/he"
             }
+        },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "dependencies": {
+                "react-is": "^16.7.0"
+            }
+        },
+        "node_modules/hoist-non-react-statics/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/hoopy": {
             "version": "0.1.4",
@@ -14977,6 +15060,11 @@
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         },
+        "node_modules/shallowequal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15350,6 +15438,36 @@
             },
             "peerDependencies": {
                 "webpack": "^5.0.0"
+            }
+        },
+        "node_modules/styled-components": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
+            "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/traverse": "^7.4.5",
+                "@emotion/is-prop-valid": "^1.1.0",
+                "@emotion/stylis": "^0.8.4",
+                "@emotion/unitless": "^0.7.4",
+                "babel-plugin-styled-components": ">= 1.12.0",
+                "css-to-react-native": "^3.0.0",
+                "hoist-non-react-statics": "^3.0.0",
+                "shallowequal": "^1.1.0",
+                "supports-color": "^5.5.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/styled-components"
+            },
+            "peerDependencies": {
+                "react": ">= 16.8.0",
+                "react-dom": ">= 16.8.0",
+                "react-is": ">= 16.8.0"
             }
         },
         "node_modules/stylehacks": {
@@ -18403,6 +18521,29 @@
             "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
             "requires": {}
         },
+        "@emotion/is-prop-valid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+            "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+            "requires": {
+                "@emotion/memoize": "^0.8.0"
+            }
+        },
+        "@emotion/memoize": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+            "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+        },
+        "@emotion/stylis": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+            "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+        },
+        "@emotion/unitless": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+        },
         "@eslint/eslintrc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
@@ -20668,6 +20809,23 @@
                 "@babel/helper-define-polyfill-provider": "^0.3.3"
             }
         },
+        "babel-plugin-styled-components": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+            "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.16.0",
+                "@babel/helper-module-imports": "^7.16.0",
+                "babel-plugin-syntax-jsx": "^6.18.0",
+                "lodash": "^4.17.11",
+                "picomatch": "^2.3.0"
+            }
+        },
+        "babel-plugin-syntax-jsx": {
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+            "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+        },
         "babel-plugin-transform-react-remove-prop-types": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
@@ -20911,6 +21069,11 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
+        },
+        "camelize": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
         },
         "caniuse-api": {
             "version": "3.0.0",
@@ -21232,6 +21395,11 @@
                 "postcss-selector-parser": "^6.0.9"
             }
         },
+        "css-color-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+        },
         "css-declaration-sorter": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
@@ -21338,6 +21506,16 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
             "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+        },
+        "css-to-react-native": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+            "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+            "requires": {
+                "camelize": "^1.0.0",
+                "css-color-keywords": "^1.0.0",
+                "postcss-value-parser": "^4.0.2"
+            }
         },
         "css-tree": {
             "version": "1.0.0-alpha.37",
@@ -23130,6 +23308,21 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        },
+        "hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "requires": {
+                "react-is": "^16.7.0"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "16.13.1",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+                }
+            }
         },
         "hoopy": {
             "version": "0.1.4",
@@ -27575,6 +27768,11 @@
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         },
+        "shallowequal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+        },
         "shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -27859,6 +28057,23 @@
             "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
             "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
             "requires": {}
+        },
+        "styled-components": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
+            "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/traverse": "^7.4.5",
+                "@emotion/is-prop-valid": "^1.1.0",
+                "@emotion/stylis": "^0.8.4",
+                "@emotion/unitless": "^0.7.4",
+                "babel-plugin-styled-components": ">= 1.12.0",
+                "css-to-react-native": "^3.0.0",
+                "hoist-non-react-statics": "^3.0.0",
+                "shallowequal": "^1.1.0",
+                "supports-color": "^5.5.0"
+            }
         },
         "stylehacks": {
             "version": "5.1.1",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
+        "styled-components": "^5.3.6",
         "web-vitals": "^2.1.4"
     },
     "scripts": {

--- a/client/src/globalStyle.css
+++ b/client/src/globalStyle.css
@@ -1,0 +1,30 @@
+:root {
+    --green: #3f724d;
+    --darkgreen: #2c483f;
+    --lightgreen: #a6bb8d;
+    --lightgreen2: #ecf0e6;
+    --yellow: #eae7b1;
+    /* main colors */
+    --primary-color: var(--green);
+    /* ui colors */
+    --bg-color: var(--lightgreen2);
+    --button-color: var(--green);
+    --button-dark-color: var(--darkgreen);
+    /* font size */
+    --font-head1-size: 45px;
+    --font-head2-size: 25px;
+    --font-title-size: 22.2px;
+    --font-body-size: 12px;
+    /* font weight */
+    --font-normal: 400;
+    --font-medium: 600;
+    --font-bold: 700;
+}
+/* layout */
+html {
+    height: 100%;
+    font-size: 13px;
+}
+.logo {
+    font-family: "Viga", sans-serif;
+}

--- a/client/src/globalStyle.css
+++ b/client/src/globalStyle.css
@@ -4,12 +4,29 @@
     --lightgreen: #a6bb8d;
     --lightgreen2: #ecf0e6;
     --yellow: #eae7b1;
+    --white: #fff;
     /* main colors */
     --primary-color: var(--green);
+    --secondary-color: var(--lightgreen);
     /* ui colors */
-    --bg-color: var(--lightgreen2);
+    --bg-color: var(--white);
+    --bg-on-color: var(--lightgreen2);
     --button-color: var(--green);
     --button-dark-color: var(--darkgreen);
+    --button-hover-color: var(--lightgreen);
+    --button-dark-hover-color: var(--green);
+    --tag-color: var(--lightgreen2);
+    /* box shadow */
+    --box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 8px 0px;
+    /* border-radius */
+    --border-radius-sm: 3px;
+    --border-radius-md: 5px;
+    --border-radius-lg: 7px;
+    /* line-height */
+    --lh-initial: 13;
+    --line-height-sm: calc((var(--lh-initial) + 2) / var(--lh-initial));
+    --line-height-md: calc((var(--lh-initial) + 4) / var(--lh-initial));
+    --line-height-lg: calc((var(--lh-initial) + 8) / var(--lh-initial));
     /* font size */
     --font-head1-size: 45px;
     --font-head2-size: 25px;
@@ -25,6 +42,33 @@ html {
     height: 100%;
     font-size: 13px;
 }
+body {
+    height: 100%;
+    font-size: var(--font-body-size);
+}
+#root {
+    height: 100%;
+}
+/* logo */
 .logo {
     font-family: "Viga", sans-serif;
+}
+/* input */
+input {
+    outline: 0;
+    border-width: 0 0 1px;
+    border-color: var(--green);
+    cursor: pointer;
+}
+/* button */
+button {
+    border-radius: 3px;
+    border: none;
+    padding: 10px;
+    background-color: var(--button-color);
+    color: var(--white);
+}
+button:hover {
+    background-color: var(--button-hover-color);
+    cursor: pointer;
 }

--- a/client/src/globalStyle.css
+++ b/client/src/globalStyle.css
@@ -62,9 +62,9 @@ input {
 }
 /* button */
 button {
-    border-radius: 3px;
+    border-radius: 10px;
     border: none;
-    padding: 10px;
+    padding: 8px 10px;
     background-color: var(--button-color);
     color: var(--white);
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./reset.css";
+import "./globalStyle.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(


### PR DESCRIPTION
## 개요
- globalStyle.css 전역 스타일 추가
## 작업사항
주요 color, box-shadow, 행간, 글자크기, 전체 레이아웃, input, button 설정해놨습니다.
a 태그는 reset.css에 넣으신 것 같아서 따로 넣지 않았습니다.
대략적인 것들은 해놨는데, 아마 페이지 만들면서 추가할 부분은 추가할 것 같습니다.
## 변경사항 (존재한다면)
- index.js import 코드 추가
- components 폴더 안 test.js 삭제
## 기타