### PR TITLE
[Refactor/fe mypage] 마이페이지, 로그인 AWS 서버 임시 연결

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
                 "@testing-library/user-event": "^13.5.0",
                 "axios": "^1.2.2",
                 "http-proxy-middleware": "^2.0.6",
+                "jwt-decode": "^3.1.2",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-full-page": "^0.1.12",
@@ -11703,6 +11704,11 @@
             "engines": {
                 "node": ">=4.0"
             }
+        },
+        "node_modules/jwt-decode": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+            "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
@@ -25783,6 +25789,11 @@
                 "array-includes": "^3.1.5",
                 "object.assign": "^4.1.3"
             }
+        },
+        "jwt-decode": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+            "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
         },
         "kind-of": {
             "version": "6.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.2.2",
         "http-proxy-middleware": "^2.0.6",
+        "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-full-page": "^0.1.12",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -36,7 +36,7 @@ function App() {
                 <Route path="/signup" element={<Signup />} />
                 <Route path="/forgotPw" element={<ForgotPw />} />
                 <Route path="/counselingcenter" element={<CounselingCenter setIsFooter={setIsFooter} />} />
-                <Route path="/mypage" element={<MyPage setIsFooter={setIsFooter} />} />
+                <Route path="/mypage/:id/*" element={<MyPage setIsFooter={setIsFooter} />} />
             </Routes>
             {isFooter ? <Footer /> : null}
         </div>

--- a/client/src/components/mypage/MyPageAnswer.js
+++ b/client/src/components/mypage/MyPageAnswer.js
@@ -4,14 +4,14 @@ import axios from "axios";
 
 const MyPageAnswer = ({ userData }) => {
     const [answerListData, setAnswerListData] = useState(undefined);
-    const url = `http://localhost:3001`;
+    const url = `http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080`;
     let memberId = undefined;
     if (userData) {
         memberId = userData.memberId;
     }
 
     useEffect(() => {
-        axios.get(`${url}/comments`).then((res) => {
+        axios.get(`${url}/comments/all`).then((res) => {
             setAnswerListData(res.data);
         });
     }, []);

--- a/client/src/components/mypage/MyPageEdit.js
+++ b/client/src/components/mypage/MyPageEdit.js
@@ -14,13 +14,12 @@ const MyPageEdit = ({ name, email }) => {
     } = useForm();
     // const [inputNameValue, setInputNameValue] = useState("");
     // const [inputPWValue, setInputPWValue] = useState("");
-    const [inputEmailValue, setInputEmailValue] = useState("");
     const [inputPWCheckValue, setInputPWCheckValue] = useState("");
 
     // const navigate = useNavigate();
 
     const [editUser, setEditUser] = useState({
-        nickName: "",
+        nickName: name,
         password: "",
     });
 
@@ -29,10 +28,11 @@ const MyPageEdit = ({ name, email }) => {
     };
 
     const handleClear = () => {
-        // setInputNameValue("");
-        // setInputPWValue("");
-        setInputEmailValue("");
         setInputPWCheckValue("");
+        setEditUser({
+            nickName: name,
+            password: "",
+        });
     };
 
     // 회원정보 수정 서버 연결
@@ -68,7 +68,7 @@ const MyPageEdit = ({ name, email }) => {
                         <div className="nickname">
                             <label>닉네임</label>
                             <input
-                                value={name}
+                                value={editUser.nickName}
                                 className={errors.name && "nameInputError"}
                                 {...register("name", {
                                     required: { value: true, message: "닉네임을 입력해주세요." },
@@ -100,6 +100,7 @@ const MyPageEdit = ({ name, email }) => {
                                     },
                                 })}
                                 onChange={(e) => handleEditInputValue("password", e)}
+                                value={editUser.password}
                             />
                             {errors.password && <div className="passwordErrorMessage">{errors.password.message}</div>}
                         </div>

--- a/client/src/components/mypage/MyPageEdit.js
+++ b/client/src/components/mypage/MyPageEdit.js
@@ -5,7 +5,7 @@ import axios from "axios";
 import { useParams } from "react-router-dom";
 // import { useNavigate } from "react-router-dom";
 
-const MyPageEdit = ({ email }) => {
+const MyPageEdit = ({ name, email }) => {
     const {
         register,
         handleSubmit,
@@ -68,7 +68,7 @@ const MyPageEdit = ({ email }) => {
                         <div className="nickname">
                             <label>닉네임</label>
                             <input
-                                placeholder="김코딩"
+                                value={name}
                                 className={errors.name && "nameInputError"}
                                 {...register("name", {
                                     required: { value: true, message: "닉네임을 입력해주세요." },

--- a/client/src/components/mypage/MyPageEdit.js
+++ b/client/src/components/mypage/MyPageEdit.js
@@ -5,7 +5,7 @@ import axios from "axios";
 import { useParams } from "react-router-dom";
 // import { useNavigate } from "react-router-dom";
 
-const MyPageEdit = () => {
+const MyPageEdit = ({ email }) => {
     const {
         register,
         handleSubmit,
@@ -107,21 +107,7 @@ const MyPageEdit = () => {
                     <BottomBlock>
                         <div className="email">
                             <label>이메일</label>
-                            <input
-                                placeholder="mentaltal2023@gmail.com"
-                                autoComplete="off"
-                                value={inputEmailValue}
-                                onKeyUp={(event) => setInputEmailValue(event.value)}
-                                className={errors.email && "emailInputError"}
-                                {...register("email", {
-                                    required: { value: true, message: "이메일을 입력해주세요." },
-                                    pattern: {
-                                        value: /\S+@\S+\.\S+/,
-                                        message: "올바른 이메일 형식을 입력해주세요.",
-                                    },
-                                })}
-                            />
-                            {errors.email && <div className="emailErrorMessage">{errors.email.message}</div>}
+                            <input autoComplete="off" value={email} disabled />
                         </div>
                         <div className="passwordConfirm">
                             <label>비밀번호 재입력</label>

--- a/client/src/components/mypage/MyPageEdit.js
+++ b/client/src/components/mypage/MyPageEdit.js
@@ -49,10 +49,23 @@ const MyPageEdit = ({ name, email }) => {
         })
             .then((res) => {
                 console.log(res);
+                openModalHandler();
             })
             .catch((error) => {
                 console.log(error);
             });
+    };
+
+    // 개인정보 수정 모달
+    const [isOpen, setIsOpen] = useState(false);
+
+    const openModalHandler = () => {
+        setIsOpen(!isOpen);
+    };
+
+    // 개인정보 수정 후 모달창 확인 버튼 누르면 새로고침
+    const handleRefresh = () => {
+        window.location.reload();
     };
 
     return (
@@ -135,6 +148,14 @@ const MyPageEdit = ({ name, email }) => {
                     </ButtonContainer>
                 </form>
             </EditContainer>
+            {isOpen ? (
+                <ModalBackdrop onClick={openModalHandler}>
+                    <ModalView onClick={(event) => event.stopPropagation()}>
+                        <div className="title">개인정보 수정이 완료되었습니다.</div>
+                        <button onClick={handleRefresh}>확인</button>
+                    </ModalView>
+                </ModalBackdrop>
+            ) : null}
         </>
     );
 };
@@ -311,6 +332,53 @@ const ButtonContainer = styled.div`
         &.edit {
             background-color: var(--darkgreen);
             color: var(--white);
+        }
+    }
+`;
+
+const ModalBackdrop = styled.div`
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.4);
+`;
+
+const ModalView = styled.div.attrs((props) => ({
+    role: "dialog",
+}))`
+    background-color: whitesmoke;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 380px;
+    height: 200px;
+    margin: 0 auto;
+    border-radius: 30px;
+    font-family: "Nanum Gothic", sans-serif;
+    padding: 20px;
+
+    .title {
+        font-size: 20px;
+        font-weight: var(--font-bold);
+        color: var(--darkgreen);
+        padding-bottom: 10%;
+    }
+
+    button {
+        background-color: var(--darkgreen);
+        font-size: 17px;
+        width: 30%;
+        border-radius: 50px;
+
+        :hover {
+            background-color: var(--lightgreen);
+            cursor: pointer;
+            transition: 0.5s;
         }
     }
 `;

--- a/client/src/components/mypage/MyPageEdit.js
+++ b/client/src/components/mypage/MyPageEdit.js
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form";
 import { useState } from "react";
 import axios from "axios";
 import { useParams } from "react-router-dom";
-// import { useNavigate } from "react-router-dom";
 
 const MyPageEdit = ({ name, email }) => {
     const {
@@ -12,11 +11,7 @@ const MyPageEdit = ({ name, email }) => {
         formState: { errors },
         watch,
     } = useForm();
-    // const [inputNameValue, setInputNameValue] = useState("");
-    // const [inputPWValue, setInputPWValue] = useState("");
     const [inputPWCheckValue, setInputPWCheckValue] = useState("");
-
-    // const navigate = useNavigate();
 
     const [editUser, setEditUser] = useState({
         nickName: name,

--- a/client/src/components/mypage/MyPageEdit.js
+++ b/client/src/components/mypage/MyPageEdit.js
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import { useForm } from "react-hook-form";
 import { useState } from "react";
+import axios from "axios";
+import { useParams } from "react-router-dom";
 // import { useNavigate } from "react-router-dom";
 
 const MyPageEdit = () => {
@@ -10,18 +12,52 @@ const MyPageEdit = () => {
         formState: { errors },
         watch,
     } = useForm();
-    const [inputNameValue, setInputNameValue] = useState("");
-    const [inputPWValue, setInputPWValue] = useState("");
+    // const [inputNameValue, setInputNameValue] = useState("");
+    // const [inputPWValue, setInputPWValue] = useState("");
     const [inputEmailValue, setInputEmailValue] = useState("");
     const [inputPWCheckValue, setInputPWCheckValue] = useState("");
 
     // const navigate = useNavigate();
 
+    const [editUser, setEditUser] = useState({
+        nickName: "",
+        password: "",
+    });
+
+    const handleEditInputValue = (key, e) => {
+        setEditUser({ ...editUser, [key]: e.target.value });
+    };
+
     const handleClear = () => {
-        setInputNameValue("");
-        setInputPWValue("");
+        // setInputNameValue("");
+        // setInputPWValue("");
         setInputEmailValue("");
         setInputPWCheckValue("");
+    };
+
+    // 회원정보 수정 서버 연결
+    const { id } = useParams();
+
+    const handleUpdateRequest = () => {
+        const { nickName, password } = editUser;
+
+        return axios({
+            method: "patch",
+            url: `/members/${id}`,
+            headers: {
+                Authorization: localStorage.getItem("loginToken"),
+            },
+            data: {
+                nickName: nickName,
+                password: password,
+            },
+        })
+            .then((res) => {
+                console.log(res);
+            })
+            .catch((error) => {
+                console.log(error);
+            });
     };
 
     return (
@@ -34,8 +70,6 @@ const MyPageEdit = () => {
                             <input
                                 placeholder="김코딩"
                                 className={errors.name && "nameInputError"}
-                                value={inputNameValue}
-                                onKeyUp={(event) => setInputNameValue(event.value)}
                                 {...register("name", {
                                     required: { value: true, message: "닉네임을 입력해주세요." },
                                     minLength: {
@@ -47,6 +81,7 @@ const MyPageEdit = () => {
                                         message: "10 글자 이하로 입력해주세요.",
                                     },
                                 })}
+                                onChange={(e) => handleEditInputValue("nickName", e)}
                             />
                             {errors.name && <div className="nameErrorMessage">{errors.name.message}</div>}
                         </div>
@@ -56,8 +91,6 @@ const MyPageEdit = () => {
                                 placeholder="새로운 비밀번호를 입력해주세요."
                                 autoComplete="new-password"
                                 type="password"
-                                value={inputPWValue}
-                                onKeyUp={(event) => setInputPWValue(event.value)}
                                 className={errors.password && "passwordInputError"}
                                 {...register("password", {
                                     required: { value: true, message: "비밀번호를 입력해주세요." },
@@ -66,6 +99,7 @@ const MyPageEdit = () => {
                                         message: "8자리 이상 비밀번호를 입력해주세요.",
                                     },
                                 })}
+                                onChange={(e) => handleEditInputValue("password", e)}
                             />
                             {errors.password && <div className="passwordErrorMessage">{errors.password.message}</div>}
                         </div>
@@ -113,7 +147,7 @@ const MyPageEdit = () => {
                         <button className="clear" onClick={handleClear}>
                             취소
                         </button>
-                        <button className="edit" type="submit">
+                        <button className="edit" type="submit" onClick={handleUpdateRequest}>
                             회원정보 수정
                         </button>
                     </ButtonContainer>

--- a/client/src/components/mypage/MyPagePosts.js
+++ b/client/src/components/mypage/MyPagePosts.js
@@ -6,7 +6,7 @@ import axios from "axios";
 const MyPagePosts = ({ userData }) => {
     // Server Data
     const [postListData, setPostListData] = useState(undefined);
-    const url = `http://localhost:3001`;
+    const url = `http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080`;
     let memberId = undefined;
     if (userData) {
         memberId = userData.memberId;
@@ -14,7 +14,7 @@ const MyPagePosts = ({ userData }) => {
 
     useEffect(() => {
         axios
-            .get(`${url}/boards`)
+            .get(`${url}/boards/all`)
             .then((res) => {
                 setPostListData(res.data);
             })

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -64,17 +64,6 @@ const Login = () => {
         },
     });
 
-    // const onSubmit = async (data) => {
-    //     try {
-    //         await axios.post(`http://localhost:3000/login`, data).then((data) => {
-    //             navigate("/");
-    //             console.log(data);
-    //         });
-    //     } catch (error) {
-    //         console.error(error);
-    //     }
-    // };
-
     return (
         <>
             <LoginContainer>

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,10 +1,111 @@
 import React, { useState } from "react";
-// import axios from "axios";
 import "../globalStyle.css";
 import styled from "styled-components";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
+
+const Login = () => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm();
+
+    const navigate = useNavigate();
+
+    const [loginInfo, setLoginInfo] = useState({
+        email: "",
+        password: "",
+    });
+
+    const [isLogin, setIsLogin] = useState(false); // 로그인 여부
+    const [userInfo, setUserInfo] = useState(null); // 회원 정보
+
+    const handleInputValue = (key, e) => {
+        setLoginInfo({ ...loginInfo, [key]: e.target.value });
+    };
+
+    const handleLoginRequest = () => {
+        const { email, password } = loginInfo;
+
+        return (
+            axios
+                // proxy 적용해서 도메인 제거함. CORS 문제 해결 후 수정
+                .post("/members/login", { email, password })
+                .then((res) => {
+                    localStorage.setItem("loginToken", res.headers.authorization);
+                    setIsLogin(true);
+                    setUserInfo({ email });
+                    navigate("/main");
+                })
+                .catch((err) => {
+                    console.log(err);
+                })
+        );
+    };
+
+    const EMAIL_REGEX = /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
+    const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{4,}/;
+
+    const emailRegister = register("email", {
+        required: { value: true, message: "이메일을 입력해주세요." },
+        pattern: {
+            value: EMAIL_REGEX,
+            message: "이메일 형식에 맞게 입력해주세요.",
+        },
+    });
+
+    const passwordRegister = register("password", {
+        required: { value: true, message: "비밀번호를 입력해주세요." },
+        pattern: {
+            value: PASSWORD_REGEX,
+            message: "비밀번호를 입력해주세요.",
+        },
+    });
+
+    // const onSubmit = async (data) => {
+    //     try {
+    //         await axios.post(`http://localhost:3000/login`, data).then((data) => {
+    //             navigate("/");
+    //             console.log(data);
+    //         });
+    //     } catch (error) {
+    //         console.error(error);
+    //     }
+    // };
+
+    return (
+        <>
+            <LoginContainer>
+                <LoginFormBox onSubmit={handleSubmit()}>
+                    <InputBox>
+                        <InputText> 이메일</InputText>
+                        <EmailInput type="text" error={errors.email?.message === undefined ? "" : "error"} {...emailRegister} onChange={(e) => handleInputValue("email", e)} />
+                        <ErrorText>{errors.email?.message}</ErrorText>
+                    </InputBox>
+                    <InputBox>
+                        <InputText> 비밀번호</InputText>
+                        <PwInput type="password" error={errors.password?.message === undefined ? "" : "error"} {...passwordRegister} onChange={(e) => handleInputValue("password", e)} />
+                        <ErrorText>{errors.password?.message}</ErrorText>
+                    </InputBox>
+                    <LoginBtn onClick={handleLoginRequest}>로그인</LoginBtn>
+                    <LinkBox>
+                        아직 회원이 아니신가요?
+                        <SignupLink href="/signup">회원가입하기</SignupLink>
+                    </LinkBox>
+                    <LinkBox>
+                        비밀번호가 생각나지 않나요?
+                        <PwLink href="/ForgotPw">비밀번호 찾기</PwLink>
+                    </LinkBox>
+                </LoginFormBox>
+                <KalkBtn> 카카오톡으로 로그인하기</KalkBtn>
+            </LoginContainer>
+        </>
+    );
+};
+
+export default Login;
 
 const LoginContainer = styled.div`
     display: flex;
@@ -139,105 +240,3 @@ const KalkBtn = styled.button`
     border-radius: 7px;
     box-shadow: rgb(0 0 0 / 5%) 0px 0px 4px, rgb(0 0 0 / 5%) 0px 0px 8px, rgb(0 0 0 / 10%) 0px 1px 4px;
 `;
-
-const Login = () => {
-    const {
-        register,
-        handleSubmit,
-        formState: { errors },
-    } = useForm();
-
-    const navigate = useNavigate();
-
-    const [loginInfo, setLoginInfo] = useState({
-        email: "",
-        password: "",
-    });
-
-    const [isLogin, setIsLogin] = useState(false); // 로그인 여부
-    const [userInfo, setUserInfo] = useState(null); // 회원 정보
-
-    const handleInputValue = (key, e) => {
-        setLoginInfo({ ...loginInfo, [key]: e.target.value });
-    };
-
-    const handleLoginRequest = () => {
-        const { email, password } = loginInfo;
-
-        return (
-            axios
-                // proxy 적용해서 도메인 제거함. CORS 문제 해결 후 수정
-                .post("/members/login", { email, password })
-                .then((res) => {
-                    localStorage.setItem("loginToken", res.headers.authorization);
-                    setIsLogin(true);
-                    setUserInfo({ email });
-                    console.log(res);
-                })
-                .catch((err) => {
-                    console.log(err);
-                })
-        );
-    };
-
-    const EMAIL_REGEX = /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
-    const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{4,}/;
-
-    const emailRegister = register("email", {
-        required: { value: true, message: "이메일을 입력해주세요." },
-        pattern: {
-            value: EMAIL_REGEX,
-            message: "이메일 형식에 맞게 입력해주세요.",
-        },
-    });
-
-    const passwordRegister = register("password", {
-        required: { value: true, message: "비밀번호를 입력해주세요." },
-        pattern: {
-            value: PASSWORD_REGEX,
-            message: "비밀번호를 입력해주세요.",
-        },
-    });
-
-    // const onSubmit = async (data) => {
-    //     try {
-    //         await axios.post(`http://localhost:3000/login`, data).then((data) => {
-    //             navigate("/");
-    //             console.log(data);
-    //         });
-    //     } catch (error) {
-    //         console.error(error);
-    //     }
-    // };
-
-    return (
-        <>
-            <LoginContainer>
-                <LoginFormBox onSubmit={handleSubmit()}>
-                    <InputBox>
-                        <InputText> 이메일</InputText>
-                        <EmailInput type="text" error={errors.email?.message === undefined ? "" : "error"} {...emailRegister} onChange={(e) => handleInputValue("email", e)} />
-                        <ErrorText>{errors.email?.message}</ErrorText>
-                    </InputBox>
-                    <InputBox>
-                        <InputText> 비밀번호</InputText>
-                        <PwInput type="password" error={errors.password?.message === undefined ? "" : "error"} {...passwordRegister} onChange={(e) => handleInputValue("password", e)} />
-                        <ErrorText>{errors.password?.message}</ErrorText>
-                    </InputBox>
-                    <LoginBtn onClick={handleLoginRequest}>로그인</LoginBtn>
-                    <LinkBox>
-                        아직 회원이 아니신가요?
-                        <SignupLink href="/signup">회원가입하기</SignupLink>
-                    </LinkBox>
-                    <LinkBox>
-                        비밀번호가 생각나지 않나요?
-                        <PwLink href="/ForgotPw">비밀번호 찾기</PwLink>
-                    </LinkBox>
-                </LoginFormBox>
-                <KalkBtn> 카카오톡으로 로그인하기</KalkBtn>
-            </LoginContainer>
-        </>
-    );
-};
-
-export default Login;

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 // import axios from "axios";
 import "../globalStyle.css";
 import styled from "styled-components";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
+import axios from "axios";
 
 const LoginContainer = styled.div`
     display: flex;
@@ -143,10 +144,41 @@ const Login = () => {
     const {
         register,
         handleSubmit,
-        formState: { errors }
+        formState: { errors },
     } = useForm();
 
     const navigate = useNavigate();
+
+    const [loginInfo, setLoginInfo] = useState({
+        email: "",
+        password: "",
+    });
+
+    const [isLogin, setIsLogin] = useState(false); // 로그인 여부
+    const [userInfo, setUserInfo] = useState(null); // 회원 정보
+
+    const handleInputValue = (key, e) => {
+        setLoginInfo({ ...loginInfo, [key]: e.target.value });
+    };
+
+    const handleLoginRequest = () => {
+        const { email, password } = loginInfo;
+
+        return (
+            axios
+                // proxy 적용해서 도메인 제거함. CORS 문제 해결 후 수정
+                .post("/members/login", { email, password })
+                .then((res) => {
+                    localStorage.setItem("loginToken", res.headers.authorization);
+                    setIsLogin(true);
+                    setUserInfo({ email });
+                    console.log(res);
+                })
+                .catch((err) => {
+                    console.log(err);
+                })
+        );
+    };
 
     const EMAIL_REGEX = /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
     const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{4,}/;
@@ -155,16 +187,16 @@ const Login = () => {
         required: { value: true, message: "이메일을 입력해주세요." },
         pattern: {
             value: EMAIL_REGEX,
-            message: "이메일 형식에 맞게 입력해주세요."
-        }
+            message: "이메일 형식에 맞게 입력해주세요.",
+        },
     });
 
     const passwordRegister = register("password", {
         required: { value: true, message: "비밀번호를 입력해주세요." },
         pattern: {
             value: PASSWORD_REGEX,
-            message: "비밀번호를 입력해주세요."
-        }
+            message: "비밀번호를 입력해주세요.",
+        },
     });
 
     // const onSubmit = async (data) => {
@@ -184,15 +216,15 @@ const Login = () => {
                 <LoginFormBox onSubmit={handleSubmit()}>
                     <InputBox>
                         <InputText> 이메일</InputText>
-                        <EmailInput type="text" error={errors.email?.message === undefined ? "" : "error"} {...emailRegister} />
+                        <EmailInput type="text" error={errors.email?.message === undefined ? "" : "error"} {...emailRegister} onChange={(e) => handleInputValue("email", e)} />
                         <ErrorText>{errors.email?.message}</ErrorText>
                     </InputBox>
                     <InputBox>
                         <InputText> 비밀번호</InputText>
-                        <PwInput type="password" error={errors.password?.message === undefined ? "" : "error"} {...passwordRegister} />
+                        <PwInput type="password" error={errors.password?.message === undefined ? "" : "error"} {...passwordRegister} onChange={(e) => handleInputValue("password", e)} />
                         <ErrorText>{errors.password?.message}</ErrorText>
                     </InputBox>
-                    <LoginBtn>로그인</LoginBtn>
+                    <LoginBtn onClick={handleLoginRequest}>로그인</LoginBtn>
                     <LinkBox>
                         아직 회원이 아니신가요?
                         <SignupLink href="/signup">회원가입하기</SignupLink>

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -37,12 +37,6 @@ const MyPage = ({ setIsFooter }) => {
 
     useEffect(() => {
         setIsFooter(false);
-        // axios.get(`${url}/members/${memberId}`).then((res) => {
-        //     // 임시 유저 데이터 가져오는 테스트 코드. token을 받아오게 되면 수정 예정
-        //     // console.log(res);
-        //     setUserData(res.data);
-        // });
-
         const userDataList = async () => {
             const userData2 = await userProfileData(id);
             setUserData(userData2);

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -71,6 +71,13 @@ const MyPage = ({ setIsFooter }) => {
         setChecked(index);
     }
 
+    // 회원탈퇴 모달
+    const [isOpen, setIsOpen] = useState(false);
+
+    const openModalHandler = () => {
+        setIsOpen(!isOpen);
+    };
+
     return (
         <>
             <MyPageContainer>
@@ -79,7 +86,9 @@ const MyPage = ({ setIsFooter }) => {
                     <div className="textContainer">
                         <p className="userName">{userData && userData.memberName} 님</p>
                         <p className="email">{userData && userData.email}</p>
-                        <p className="leaveText">회원 탈퇴</p>
+                        <p className="deleteUserText" onClick={openModalHandler}>
+                            회원 탈퇴
+                        </p>
                     </div>
                 </MyPageHeader>
                 <MyPageTab>
@@ -95,6 +104,21 @@ const MyPage = ({ setIsFooter }) => {
                 </MyPageTab>
                 <MyPageBody>{checked === 0 ? <MyPagePosts userData={userData} /> : checked === 1 ? <MyPageAnswer userData={userData} /> : <MyPageEdit />}</MyPageBody>
             </MyPageContainer>
+            {isOpen ? (
+                <ModalBackdrop onClick={openModalHandler}>
+                    <ModalView onClick={(event) => event.stopPropagation()}>
+                        <div className="title">회원 탈퇴</div>
+                        <div className="description1">
+                            지금까지 MENTALTAL 서비스를
+                            <br /> 이용해주셔서 감사합니다.
+                        </div>
+                        <div className="description2">
+                            하단 버튼을 눌러 회원을 탈퇴하면 <br /> MENTALTAL 서비스 내 계정 정보가 <br /> 삭제되고 복구할 수 없습니다.
+                        </div>
+                        <button>탈퇴하기</button>
+                    </ModalView>
+                </ModalBackdrop>
+            ) : null}
         </>
     );
 };
@@ -143,12 +167,20 @@ const MyPageHeader = styled.div`
         }
 
         .email,
-        .leaveText {
+        .deleteUserText {
             color: var(--green);
             padding-top: 8px;
 
             &.email {
                 text-decoration: underline;
+            }
+
+            &.deleteUserText {
+                :hover {
+                    cursor: pointer;
+                    color: var(--darkgreen);
+                    transition: 0.5s;
+                }
             }
         }
     }
@@ -213,4 +245,65 @@ const MyPageTab = styled.div`
 
 const MyPageBody = styled.div`
     margin-bottom: 50px;
+`;
+
+const ModalBackdrop = styled.div`
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.4);
+`;
+
+const ModalView = styled.div.attrs((props) => ({
+    // attrs 메소드를 이용해서 아래와 같이 div 엘리먼트에 속성을 추가할 수 있습니다.
+    role: "dialog",
+}))`
+    background-color: whitesmoke;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 350px;
+    height: 400px;
+    margin: 0 auto;
+    border-radius: 30px;
+    font-family: "Nanum Gothic", sans-serif;
+    padding: 20px;
+
+    .title {
+        font-size: 20px;
+        font-weight: var(--font-bold);
+        color: var(--darkgreen);
+        padding-bottom: 10%;
+    }
+    .description1,
+    .description2 {
+        font-size: 15px;
+        line-height: 150%;
+        text-align: center;
+        color: var(--darkgreen);
+
+        &.description2 {
+            padding-top: 2%;
+            padding-bottom: 15%;
+        }
+    }
+
+    button {
+        background-color: var(--darkgreen);
+        font-size: 17px;
+        width: 80%;
+        border-radius: 50px;
+
+        :hover {
+            background-color: var(--lightgreen);
+            color: var(--darkgreen);
+            cursor: pointer;
+            transition: 0.5s;
+        }
+    }
 `;

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -6,6 +6,7 @@ import MyPageEdit from "../components/mypage/MyPageEdit";
 import axios from "axios";
 import { useParams } from "react-router-dom";
 import jwt_decode from "jwt-decode";
+import { useNavigate } from "react-router-dom";
 
 const MyPage = ({ setIsFooter }) => {
     const { id } = useParams();
@@ -78,6 +79,26 @@ const MyPage = ({ setIsFooter }) => {
         setIsOpen(!isOpen);
     };
 
+    const navigate = useNavigate();
+    // 회원탈퇴 서버 연결
+    const userDelete = () => {
+        axios({
+            method: "delete",
+            url: `/members/${id}`,
+            headers: {
+                Authorization: localStorage.getItem("loginToken"),
+            },
+        })
+            .then((res) => {
+                console.log(`${id}번 유저가 삭제됨`);
+                localStorage.removeItem("loginToken");
+                navigate("/");
+            })
+            .catch((error) => {
+                console.log(error);
+            });
+    };
+
     return (
         <>
             <MyPageContainer>
@@ -115,7 +136,7 @@ const MyPage = ({ setIsFooter }) => {
                         <div className="description2">
                             하단 버튼을 눌러 회원을 탈퇴하면 <br /> MENTALTAL 서비스 내 계정 정보가 <br /> 삭제되고 복구할 수 없습니다.
                         </div>
-                        <button>탈퇴하기</button>
+                        <button onClick={userDelete}>탈퇴하기</button>
                     </ModalView>
                 </ModalBackdrop>
             ) : null}
@@ -301,7 +322,6 @@ const ModalView = styled.div.attrs((props) => ({
 
         :hover {
             background-color: var(--lightgreen);
-            color: var(--darkgreen);
             cursor: pointer;
             transition: 0.5s;
         }

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -4,17 +4,49 @@ import MyPagePosts from "../components/mypage/MyPagePosts";
 import MyPageAnswer from "../components/mypage/MyPageAnswer";
 import MyPageEdit from "../components/mypage/MyPageEdit";
 import axios from "axios";
+import { useParams } from "react-router-dom";
+import jwt_decode from "jwt-decode";
 
 const MyPage = ({ setIsFooter }) => {
+    const { id } = useParams();
     const [userData, setUserData] = useState(undefined);
-    const url = `http://localhost:3001`;
+    const url = `http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080`;
+    // const getMemberId = () => {
+    //     const memberId = localStorage.getItem("memberId") ? JSON.parse(localStorage.getItem("memberId")) : null;
+    //     console.log(memberId);
+    //     return memberId;
+    // };
+    // const memberId = getMemberId();
+
+    let decoded;
+    let loginToken = window.localStorage.getItem("loginToken");
+
+    if (loginToken) {
+        decoded = jwt_decode(loginToken);
+        console.log(decoded);
+    }
+
+    const userProfileData = async (id) => {
+        const member = await axios.get(`${url}/members/${id}`);
+        return {
+            memberName: member.data.data.nickName,
+            email: member.data.data.email,
+        };
+    };
 
     useEffect(() => {
         setIsFooter(false);
-        axios.get(`${url}/members`).then((res) => {
-            // 임시 유저 데이터 가져오는 테스트 코드. token을 받아오게 되면 수정 예정
-            setUserData(res.data[0]);
-        });
+        // axios.get(`${url}/members/${memberId}`).then((res) => {
+        //     // 임시 유저 데이터 가져오는 테스트 코드. token을 받아오게 되면 수정 예정
+        //     // console.log(res);
+        //     setUserData(res.data);
+        // });
+
+        const userDataList = async () => {
+            const userData2 = await userProfileData(id);
+            setUserData(userData2);
+        };
+        userDataList();
     }, []);
 
     const [openTab, setOpenTab] = useState([
@@ -45,7 +77,7 @@ const MyPage = ({ setIsFooter }) => {
                 <MyPageHeader>
                     <div className="imgContainer"></div>
                     <div className="textContainer">
-                        <p className="userName">{userData && userData.name} 님</p>
+                        <p className="userName">{userData && userData.memberName} 님</p>
                         <p className="email">{userData && userData.email}</p>
                         <p className="leaveText">회원 탈퇴</p>
                     </div>

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -23,7 +23,7 @@ const MyPage = ({ setIsFooter }) => {
 
     if (loginToken) {
         decoded = jwt_decode(loginToken);
-        console.log(decoded);
+        // console.log(decoded);
     }
 
     const userProfileData = async (id) => {

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -30,7 +30,7 @@ const MyPage = ({ setIsFooter }) => {
     const userProfileData = async (id) => {
         const member = await axios.get(`${url}/members/${id}`);
         return {
-            memberName: member.data.data.nickName,
+            nickName: member.data.data.nickName,
             email: member.data.data.email,
         };
     };
@@ -105,7 +105,7 @@ const MyPage = ({ setIsFooter }) => {
                 <MyPageHeader>
                     <div className="imgContainer"></div>
                     <div className="textContainer">
-                        <p className="userName">{userData && userData.memberName} 님</p>
+                        <p className="userName">{userData && userData.nickName} 님</p>
                         <p className="email">{userData && userData.email}</p>
                         <p className="deleteUserText" onClick={openModalHandler}>
                             회원 탈퇴
@@ -123,7 +123,9 @@ const MyPage = ({ setIsFooter }) => {
                         })}
                     </div>
                 </MyPageTab>
-                <MyPageBody>{checked === 0 ? <MyPagePosts userData={userData} /> : checked === 1 ? <MyPageAnswer userData={userData} /> : <MyPageEdit email={userData.email} />}</MyPageBody>
+                <MyPageBody>
+                    {checked === 0 ? <MyPagePosts userData={userData} /> : checked === 1 ? <MyPageAnswer userData={userData} /> : <MyPageEdit name={userData.nickName} email={userData.email} />}
+                </MyPageBody>
             </MyPageContainer>
             {isOpen ? (
                 <ModalBackdrop onClick={openModalHandler}>

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -123,7 +123,7 @@ const MyPage = ({ setIsFooter }) => {
                         })}
                     </div>
                 </MyPageTab>
-                <MyPageBody>{checked === 0 ? <MyPagePosts userData={userData} /> : checked === 1 ? <MyPageAnswer userData={userData} /> : <MyPageEdit />}</MyPageBody>
+                <MyPageBody>{checked === 0 ? <MyPagePosts userData={userData} /> : checked === 1 ? <MyPageAnswer userData={userData} /> : <MyPageEdit email={userData.email} />}</MyPageBody>
             </MyPageContainer>
             {isOpen ? (
                 <ModalBackdrop onClick={openModalHandler}>

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -15,4 +15,11 @@ module.exports = function (app) {
             changeOrigin: true,
         })
     );
+    app.use(
+        "/members/login",
+        createProxyMiddleware({
+            target: "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080/",
+            changeOrigin: true,
+        })
+    );
 };

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -22,4 +22,11 @@ module.exports = function (app) {
             changeOrigin: true,
         })
     );
+    app.use(
+        "/mypage/:id/*",
+        createProxyMiddleware({
+            target: "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080/",
+            changeOrigin: true,
+        })
+    );
 };


### PR DESCRIPTION
## 개요
proxy를 사용해서 로그인 기능, 마이페이지 회원정보 관련 데이터 받아오기 구현했습니다. 
memberId가 필요한 작업(Nav바에서 마이페이지를 클릭할 경우 해당 memberId path로 이동, 작성글과 작성답변 렌더링)은 백엔드 작업 완료 시까지 보류 중입니다.
## 작업사항
- 마이페이지 회원정보 서버 연결
- 회원탈퇴 서버 연결
- 개인정보 수정 서버 연결
- 일반 로그인 서버 연결
- 회원탈퇴, 개인정보 수정 시 모달창 띄우기
- 마이페이지 관련 UI 조정
## 변경사항 (존재한다면)
- **[App.js]** mypage Route path를 변경했습니다.
- **[setupProxy.js]** 로그인, 마이페이지 관련 코드 추가했습니다.
## 기타
- 토큰 데이터 테스트해보느라 jwt-decode를 설치했습니다. 
  - `npm install jwt-decode --legacy-peer-deps`