### PR TITLE
[Feat/fe login] 회원가입 기능 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,7 @@
                 "http-proxy-middleware": "^2.0.6",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "react-hook-form": "^7.41.5",
+                "react-hook-form": "^7.42.1",
                 "react-intersection-observer": "^9.4.1",
                 "react-js-pagination": "^3.0.3",
                 "react-loading": "^2.0.3",
@@ -24,7 +24,8 @@
                 "recoil": "^0.7.6",
                 "recoil-persist": "^4.2.0",
                 "styled-components": "^5.3.6",
-                "swiper": "^8.4.5",
+                "sweetalert2": "^11.7.0",
+                "swiper": "^8.4.6",
                 "web-vitals": "^2.1.4"
             }
         },
@@ -14359,9 +14360,9 @@
             "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
         },
         "node_modules/react-hook-form": {
-            "version": "7.41.5",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
-            "integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==",
+            "version": "7.42.1",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.42.1.tgz",
+            "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
             "engines": {
                 "node": ">=12.22.0"
             },
@@ -15848,10 +15849,19 @@
                 "boolbase": "~1.0.0"
             }
         },
+        "node_modules/sweetalert2": {
+            "version": "11.7.0",
+            "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.7.0.tgz",
+            "integrity": "sha512-ICeeGhIsmzCwRD/XjZrBYk+SDQzwfGvIdxkeSpPFgkPwbnoaGnaZ4cOb7AD/iC5o50snQUF6w23MfFAGk1+J7A==",
+            "funding": {
+                "type": "individual",
+                "url": "https://github.com/sponsors/limonte"
+            }
+        },
         "node_modules/swiper": {
-            "version": "8.4.5",
-            "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.5.tgz",
-            "integrity": "sha512-zveyEFBBv4q1sVkbJHnuH4xCtarKieavJ4SxP0QEHvdpPLJRuD7j/Xg38IVVLbp7Db6qrPsLUePvxohYx39Agw==",
+            "version": "8.4.6",
+            "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.6.tgz",
+            "integrity": "sha512-HACW035vBz2T6Kfut23EAzXhcDpgR8doX+wjq0ZUvJgS5SQApGrV885DAPLBFnmPUISsAhNSVxPKDxqroFvXvQ==",
             "funding": [
                 {
                     "type": "patreon",
@@ -27527,9 +27537,9 @@
             "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
         },
         "react-hook-form": {
-            "version": "7.41.5",
-            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
-            "integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==",
+            "version": "7.42.1",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.42.1.tgz",
+            "integrity": "sha512-2UIGqwMZksd5HS55crTT1ATLTr0rAI4jS7yVuqTaoRVDhY2Qc4IyjskCmpnmdYqUNOYFy04vW253tb2JRVh+IQ==",
             "requires": {}
         },
         "react-intersection-observer": {
@@ -28619,10 +28629,15 @@
                 }
             }
         },
+        "sweetalert2": {
+            "version": "11.7.0",
+            "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.7.0.tgz",
+            "integrity": "sha512-ICeeGhIsmzCwRD/XjZrBYk+SDQzwfGvIdxkeSpPFgkPwbnoaGnaZ4cOb7AD/iC5o50snQUF6w23MfFAGk1+J7A=="
+        },
         "swiper": {
-            "version": "8.4.5",
-            "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.5.tgz",
-            "integrity": "sha512-zveyEFBBv4q1sVkbJHnuH4xCtarKieavJ4SxP0QEHvdpPLJRuD7j/Xg38IVVLbp7Db6qrPsLUePvxohYx39Agw==",
+            "version": "8.4.6",
+            "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.6.tgz",
+            "integrity": "sha512-HACW035vBz2T6Kfut23EAzXhcDpgR8doX+wjq0ZUvJgS5SQApGrV885DAPLBFnmPUISsAhNSVxPKDxqroFvXvQ==",
             "requires": {
                 "dom7": "^4.0.4",
                 "ssr-window": "^4.0.2"

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
         "http-proxy-middleware": "^2.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.41.5",
+        "react-hook-form": "^7.42.1",
         "react-intersection-observer": "^9.4.1",
         "react-js-pagination": "^3.0.3",
         "react-loading": "^2.0.3",
@@ -19,7 +19,8 @@
         "recoil": "^0.7.6",
         "recoil-persist": "^4.2.0",
         "styled-components": "^5.3.6",
-        "swiper": "^8.4.5",
+        "sweetalert2": "^11.7.0",
+        "swiper": "^8.4.6",
         "web-vitals": "^2.1.4"
     },
     "scripts": {

--- a/client/src/pages/Signup.js
+++ b/client/src/pages/Signup.js
@@ -17,7 +17,7 @@ const Signup = () => {
 
     const NICKNAME_REGEX = /(?=.*[a-z0-9가-힣]).{2,}/;
     const EMAIL_REGEX = /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
-    const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{4,}/;
+    const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{8,}/;
 
     const nickNameRegister = register("nickName", {
         required: { value: true, message: "닉네임을 입력해주세요." },
@@ -90,16 +90,17 @@ const Signup = () => {
         </>
     );
 };
-
 const SignupContainer = styled.div`
     display: flex;
     margin-top: 15px;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    width: 100vw;
-    background-color: #ecf0e6;
+    width: 100%;
+    background-color: var(--lightgreen2);
     min-height: 100vh;
+    padding-top: 90px;
+    padding-bottom: 90px;
 `;
 
 const SignupFormBox = styled.form`
@@ -120,21 +121,22 @@ const InputBox = styled.div`
     margin: 8px;
 `;
 
-const MainText = styled.h2`
+const MainText = styled.div`
     font-size: 25px;
     margin: 10px 0px 20px 5px;
     font-family: "Viga";
     font-weight: var(--font-bold);
-    color: #2c483f;
+    color: var(--darkgreen);
 `;
 
-const InputText = styled.label`
+const InputText = styled.div`
     display: flex;
     margin: 10px 0px 5px 5px;
-    font-weight: bold;
-    font-family: "Inter";
-    color: #2c483f;
-    font-size: 20px;
+    .text {
+        color: var(--darkgreen);
+        font-size: 20px;
+        font-weight: bold;
+    }
 `;
 
 const NameInput = styled.input`
@@ -199,10 +201,11 @@ const SingupBtn = styled.button`
     margin-bottom: 13px;
     width: 335px;
     color: white;
-    background-color: #3f724d;
+    background-color: var(--green);
     border-radius: 10px;
     padding: 10px;
     font-size: 18px;
+    font-family: "Viga";
 `;
 
 const KalkBtn = styled.button`
@@ -217,7 +220,7 @@ const KalkBtn = styled.button`
     border-radius: 10px;
     padding: 10px;
     font-size: 18px;
-    color: #3f724d;
+    color: var(--green);
     border-radius: 7px;
     box-shadow: rgb(0 0 0 / 5%) 0px 0px 4px, rgb(0 0 0 / 5%) 0px 0px 8px, rgb(0 0 0 / 10%) 0px 1px 4px;
 `;

--- a/client/src/pages/Signup.js
+++ b/client/src/pages/Signup.js
@@ -146,12 +146,10 @@ const NameInput = styled.input`
     margin-bottom: 5px;
     padding: 0.5em 0.5em;
     font-size: 18px;
-    border-color: ${(props) => (props.error ? "#de4f54" : "")};
+    border-bottom: 2px solid var(--green);
+    border-color: ${(props) => (props.error ? "#de4f54" : "var(--green)")};
     &:focus {
-        outline: none;
-        border-color: ${(props) => (props.error ? "#de4f54" : "#2c483f")};
-        border-width: 0px;
-        box-shadow: ${(props) => (props.error ? "0 0 0 4px #f7e1e1, 0 0 0 4px #f7e1e1" : "0 0 0 4px #ecf0e6, 0 0 0 4px #ecf0e6")};
+        border-color: ${(props) => (props.error ? "#de4f54" : "var(--lightgreen)")};
     }
 `;
 
@@ -162,12 +160,10 @@ const EmailInput = styled.input`
     margin-bottom: 5px;
     padding: 0.5em 0.5em;
     font-size: 18px;
-    border-color: ${(props) => (props.error ? "#de4f54" : "")};
+    border-bottom: 2px solid var(--green);
+    border-color: ${(props) => (props.error ? "#de4f54" : "var(--green)")};
     &:focus {
-        outline: none;
-        border-color: ${(props) => (props.error ? "#de4f54" : "#2c483f")};
-        border-width: 0px;
-        box-shadow: ${(props) => (props.error ? "0 0 0 4px #f7e1e1, 0 0 0 4px #f7e1e1" : "0 0 0 4px #ecf0e6, 0 0 0 4px #ecf0e6")};
+        border-color: ${(props) => (props.error ? "#de4f54" : "var(--lightgreen)")};
     }
 `;
 
@@ -178,12 +174,10 @@ const PwInput = styled.input`
     margin-bottom: 10px;
     padding: 0.5em 0.5em;
     font-size: 18px;
-    border-color: ${(props) => (props.error ? "#de4f54" : "")};
+    border-bottom: 2px solid var(--green);
+    border-color: ${(props) => (props.error ? "#de4f54" : "var(--green)")};
     &:focus {
-        outline: none;
-        border-color: ${(props) => (props.error ? "#de4f54" : "#2c483f")};
-        border-width: 0px;
-        box-shadow: ${(props) => (props.error ? "0 0 0 4px #f7e1e1, 0 0 0 4px #f7e1e1" : "0 0 0 4px #ecf0e6, 0 0 0 4px #ecf0e6")};
+        border-color: ${(props) => (props.error ? "#de4f54" : "var(--lightgreen)")};
     }
 `;
 

--- a/client/src/pages/Signup.js
+++ b/client/src/pages/Signup.js
@@ -1,9 +1,95 @@
 import React from "react";
-// import axios from "axios";
+import axios from "axios";
 import "../globalStyle.css";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import Swal from "sweetalert2";
+
+const Signup = () => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors }
+    } = useForm();
+
+    const navigate = useNavigate();
+
+    const NICKNAME_REGEX = /(?=.*[a-z0-9가-힣]).{2,}/;
+    const EMAIL_REGEX = /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
+    const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{4,}/;
+
+    const nickNameRegister = register("nickName", {
+        required: { value: true, message: "닉네임을 입력해주세요." },
+        pattern: {
+            value: NICKNAME_REGEX,
+            message: "두글자이상 입력해주세요."
+        }
+    });
+
+    const emailRegister = register("email", {
+        required: { value: true, message: "이메일을 입력해주세요." },
+        pattern: {
+            value: EMAIL_REGEX,
+            message: "이메일 형식에 맞게 입력해주세요."
+        }
+    });
+
+    const passwordRegister = register("password", {
+        required: { value: true, message: "비밀번호를 입력해주세요." },
+        pattern: {
+            value: PASSWORD_REGEX,
+            message: "8자 이상 영문, 숫자, 특수문자를 사용하세요."
+        }
+    });
+    const onSubmit = (data) => {
+        axios
+            .post(`/members`, data)
+            .then((res) => {
+                Swal.fire({
+                    icon: "success",
+                    text: "회원가입을 축하합니다!",
+                    width: "400px"
+                });
+                navigate("/login");
+            })
+            .catch((error) => {
+                console.log("error : ", error.response);
+                Swal.fire({
+                    icon: "error",
+                    text: "이메일 또는 닉네임이 이미 존재합니다.",
+                    width: "400px"
+                });
+            });
+    };
+
+    return (
+        <>
+            <SignupContainer>
+                <MainText>일반 회원가입</MainText>
+                <SignupFormBox onSubmit={handleSubmit(onSubmit)}>
+                    <InputBox>
+                        <InputText> 이메일</InputText>
+                        <EmailInput type="text" error={errors.email?.message === undefined ? "" : "error"} {...emailRegister} />
+                        <ErrorText>{errors.email?.message}</ErrorText>
+                    </InputBox>
+                    <InputBox>
+                        <InputText> 닉네임</InputText>
+                        <NameInput type="text" error={errors.nickName?.message === undefined ? "" : "error"} {...nickNameRegister} />
+                        <ErrorText>{errors.nickName?.message}</ErrorText>
+                    </InputBox>
+                    <InputBox>
+                        <InputText> 비밀번호</InputText>
+                        <PwInput type="password" error={errors.password?.message === undefined ? "" : "error"} {...passwordRegister} />
+                        <ErrorText>{errors.password?.message}</ErrorText>
+                    </InputBox>
+                    <SingupBtn> 회원가입</SingupBtn>
+                </SignupFormBox>
+                <KalkBtn> 카카오톡으로 회원가입하기</KalkBtn>
+            </SignupContainer>
+        </>
+    );
+};
 
 const SignupContainer = styled.div`
     display: flex;
@@ -135,80 +221,5 @@ const KalkBtn = styled.button`
     border-radius: 7px;
     box-shadow: rgb(0 0 0 / 5%) 0px 0px 4px, rgb(0 0 0 / 5%) 0px 0px 8px, rgb(0 0 0 / 10%) 0px 1px 4px;
 `;
-
-const Signup = () => {
-    const {
-        register,
-        handleSubmit,
-        formState: { errors }
-    } = useForm();
-
-    const navigate = useNavigate();
-
-    const NAME_REGEX = /(?=.*[a-z0-9가-힣]).{2,}/;
-    const EMAIL_REGEX = /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
-    const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{4,}/;
-
-    const nameRegister = register("name", {
-        required: { value: true, message: "닉네임을 입력해주세요." },
-        pattern: {
-            value: NAME_REGEX,
-            message: "두글자이상 입력해주세요."
-        }
-    });
-
-    const emailRegister = register("email", {
-        required: { value: true, message: "이메일을 입력해주세요." },
-        pattern: {
-            value: EMAIL_REGEX,
-            message: "이메일 형식에 맞게 입력해주세요."
-        }
-    });
-
-    const passwordRegister = register("password", {
-        required: { value: true, message: "비밀번호를 입력해주세요." },
-        pattern: {
-            value: PASSWORD_REGEX,
-            message: "비밀번호를 입력해주세요."
-        }
-    });
-    // const onSubmit = async (data) => {
-    //     try {
-    //         await axios.post(`http://localhost:3000/signup`, data).then((data) => {
-    //             navigate("/");
-    //             console.log(data);
-    //         });
-    //     } catch (error) {
-    //         console.error(error);
-    //     }
-    // };
-
-    return (
-        <>
-            <SignupContainer>
-                <MainText>일반 회원가입</MainText>
-                <SignupFormBox onSubmit={handleSubmit()}>
-                    <InputBox>
-                        <InputText> 이메일</InputText>
-                        <EmailInput type="text" error={errors.email?.message === undefined ? "" : "error"} {...emailRegister} />
-                        <ErrorText>{errors.email?.message}</ErrorText>
-                    </InputBox>
-                    <InputBox>
-                        <InputText> 닉네임</InputText>
-                        <NameInput type="text" error={errors.name?.message === undefined ? "" : "error"} {...nameRegister} />
-                        <ErrorText>{errors.name?.message}</ErrorText>
-                    </InputBox>
-                    <InputBox>
-                        <InputText> 비밀번호</InputText>
-                        <PwInput type="password" error={errors.password?.message === undefined ? "" : "error"} {...passwordRegister} />
-                        <ErrorText>{errors.password?.message}</ErrorText>
-                    </InputBox>
-                    <SingupBtn> 회원가입</SingupBtn>
-                </SignupFormBox>
-                <KalkBtn> 카카오톡으로 회원가입하기</KalkBtn>
-            </SignupContainer>
-        </>
-    );
-};
 
 export default Signup;

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -5,14 +5,21 @@ module.exports = function (app) {
         "/boards",
         createProxyMiddleware({
             target: "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080/",
-            changeOrigin: true,
+            changeOrigin: true
         })
     );
     app.use(
         "/comments",
         createProxyMiddleware({
             target: "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080/",
-            changeOrigin: true,
+            changeOrigin: true
+        })
+    );
+    app.use(
+        "/members",
+        createProxyMiddleware({
+            target: "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080/",
+            changeOrigin: true
         })
     );
 };


### PR DESCRIPTION
## 개요
회원 가입 기능을 구현했습니다. 

## 작업사항

- [src / setupProxy]: 프록시 파일에 회원가입을 추가했습니다. 
- styled css를 수정하며 하단으로 배치했습니다. 
- 다른 페이지들과 달랐던 focus부분의 css를 수정했습니다. 
- 같은 닉네임 혹은 이메일로 회원가입을 시도할 경우 500번 에러로 "이메일 또는 닉네임이 이미 존재합니다."라는 모달이 뜨도록 햇습니다.
- 회원 가입에 성공한 경우 login 페이지로 넘어가며, "회원가입을 축하합니다!"라는 모달이 뜨도록 했습니다. 

## 기타 
- sweetalert2를 이용해서 모달을 구현했습니다.
` npm install sweetalert2` 설치가 필요합니다.
