### PR TITLE
[feat/fe] 회원가입 모달 및 로그인시 Nav 변경

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,8 +34,8 @@ function App() {
                 <Route path="/community/:id" element={<BoardDetail setIsFooter={setIsFooter} />} />
                 <Route path="/community/edit" element={<EditBoard setIsFooter={setIsFooter} />} />
                 <Route path="/write" element={<CreateBoard setIsFooter={setIsFooter} />} />
-                <Route path="/login" element={<Login />} />
-                <Route path="/signup" element={<Signup />} />
+                <Route path="/login" element={<Login setIsFooter={setIsFooter} />} />
+                <Route path="/signup" element={<Signup setIsFooter={setIsFooter} />} />
                 <Route path="/forgotPw" element={<ForgotPw />} />
                 <Route path="/mypage/:id/*" element={<MyPage setIsFooter={setIsFooter} />} />
                 <Route path="/counselingcenter" element={<CounselingCenter setIsFooter={setIsFooter} />} />

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -46,7 +46,7 @@ const Nav = () => {
                     <Link to="/selfcheck">자가진단</Link>
                 </li>
                 <li>
-                    <Link to="/counselors">전문가</Link>
+                    <Link to="/counselor">전문가</Link>
                 </li>
                 <li>
                     <Link to="/counselingcenter">전문기관</Link>

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import NavModal from "./NavModal";
 import { memberIdState } from "../states/memberIdState";
@@ -9,11 +9,17 @@ const Nav = () => {
     // 마이페이지 클릭 시 path
     const memberId = useRecoilValue(memberIdState);
 
-    // ! 임시 - 로그인이 구현될 시 교체 예정입니다.
-    const [test, setTest] = useState(false);
-    const handleTest = () => {
-        setTest(!test);
-    };
+    // local storage login token 확인
+    const [istoken, setIstoken] = useState(false);
+
+    //memberId의 여부로 Nav버튼 상태 변경
+    useEffect(() => {
+        if (memberId === null) {
+            console.log(memberId);
+        } else {
+            setIstoken(true);
+        }
+    });
     // !
 
     // * 모달
@@ -29,7 +35,7 @@ const Nav = () => {
                     MENTALTAL
                 </Link>
                 {/* 삭제할 예정 */}
-                <button onClick={handleTest}>0</button>
+                {/* <button onClick={handleTest}>0</button> */}
             </NavTitle>
 
             <NavContainer>
@@ -45,7 +51,7 @@ const Nav = () => {
                 <li>
                     <Link to="/counselingcenter">전문기관</Link>
                 </li>
-                {test ? (
+                {istoken ? (
                     <>
                         <li>
                             <button>

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import "../globalStyle.css";
 import styled from "styled-components";
 import { useForm } from "react-hook-form";
@@ -7,7 +7,10 @@ import axios from "axios";
 import { useRecoilState } from "recoil";
 import { memberIdState } from "../states/memberIdState";
 
-const Login = () => {
+const Login = ({ setIsFooter }) => {
+    useEffect(() => {
+        setIsFooter(false);
+    });
     const [memberId, setMemberId] = useRecoilState(memberIdState);
 
     const {

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -13,14 +13,14 @@ const Login = () => {
     const {
         register,
         handleSubmit,
-        formState: { errors },
+        formState: { errors }
     } = useForm();
 
     const navigate = useNavigate();
 
     const [loginInfo, setLoginInfo] = useState({
         email: "",
-        password: "",
+        password: ""
     });
 
     const [isLogin, setIsLogin] = useState(false); // 로그인 여부
@@ -58,16 +58,16 @@ const Login = () => {
         required: { value: true, message: "이메일을 입력해주세요." },
         pattern: {
             value: EMAIL_REGEX,
-            message: "이메일 형식에 맞게 입력해주세요.",
-        },
+            message: "이메일 형식에 맞게 입력해주세요."
+        }
     });
 
     const passwordRegister = register("password", {
         required: { value: true, message: "비밀번호를 입력해주세요." },
         pattern: {
             value: PASSWORD_REGEX,
-            message: "비밀번호를 입력해주세요.",
-        },
+            message: "비밀번호를 입력해주세요."
+        }
     });
 
     return (

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -165,12 +165,10 @@ const EmailInput = styled.input`
     margin-bottom: 5px;
     padding: 0.5em 0.5em;
     font-size: 18px;
-    border-color: ${(props) => (props.error ? "#de4f54" : "")};
+    border-bottom: 2px solid var(--green);
+    border-color: ${(props) => (props.error ? "#de4f54" : "var(--green)")};
     &:focus {
-        outline: none;
-        border-color: ${(props) => (props.error ? "#de4f54" : "#2c483f")};
-        border-width: 0px;
-        box-shadow: ${(props) => (props.error ? "0 0 0 4px #f7e1e1, 0 0 0 4px #f7e1e1" : "0 0 0 4px #ecf0e6, 0 0 0 4px #ecf0e6")};
+        border-color: ${(props) => (props.error ? "#de4f54" : "var(--lightgreen)")};
     }
 `;
 
@@ -181,12 +179,10 @@ const PwInput = styled.input`
     margin-bottom: 10px;
     padding: 0.5em 0.5em;
     font-size: 18px;
-    border-color: ${(props) => (props.error ? "#de4f54" : "")};
+    border-bottom: 2px solid var(--green);
+    border-color: ${(props) => (props.error ? "#de4f54" : "var(--green)")};
     &:focus {
-        outline: none;
-        border-color: ${(props) => (props.error ? "#de4f54" : "#2c483f")};
-        border-width: 0px;
-        box-shadow: ${(props) => (props.error ? "0 0 0 4px #f7e1e1, 0 0 0 4px #f7e1e1" : "0 0 0 4px #ecf0e6, 0 0 0 4px #ecf0e6")};
+        border-color: ${(props) => (props.error ? "#de4f54" : "var(--lightgreen)")};
     }
 `;
 
@@ -268,7 +264,7 @@ const ModalBackdrop = styled.div`
 `;
 
 const ModalView = styled.div.attrs((props) => ({
-    role: "dialog",
+    role: "dialog"
 }))`
     background-color: whitesmoke;
     display: flex;

--- a/client/src/pages/Signup.js
+++ b/client/src/pages/Signup.js
@@ -10,6 +10,7 @@ const Signup = ({ setIsFooter }) => {
     useEffect(() => {
         setIsFooter(false);
     });
+
     const {
         register,
         handleSubmit,

--- a/client/src/pages/Signup.js
+++ b/client/src/pages/Signup.js
@@ -1,19 +1,176 @@
 import React from "react";
-// import axios from "axios";
+import axios from "axios";
 import "../globalStyle.css";
 import { useForm } from "react-hook-form";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
+const Signup = () => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors }
+    } = useForm();
+
+    const navigate = useNavigate();
+
+    const NICKNAME_REGEX = /(?=.*[a-z0-9가-힣]).{2,}/;
+    const EMAIL_REGEX = /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
+    const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{8,}/;
+
+    const nickNameRegister = register("nickName", {
+        required: { value: true, message: "닉네임을 입력해주세요." },
+        pattern: {
+            value: NICKNAME_REGEX,
+            message: "두글자이상 입력해주세요."
+        }
+    });
+
+    const emailRegister = register("email", {
+        required: { value: true, message: "이메일을 입력해주세요." },
+        pattern: {
+            value: EMAIL_REGEX,
+            message: "이메일 형식에 맞게 입력해주세요."
+        }
+    });
+
+    const passwordRegister = register("password", {
+        required: { value: true, message: "비밀번호를 입력해주세요." },
+        pattern: {
+            value: PASSWORD_REGEX,
+            message: "8자 이상 영문, 숫자, 특수문자를 사용하세요."
+        }
+    });
+    const onSubmit = (data) => {
+        axios
+            .post(`/members`, data)
+            .then((res) => {
+                setSuccessModal(!successModal);
+                console.log(res.status);
+            })
+            .catch((error) => {
+                setFailModal(!failModal);
+                console.log(error.message);
+            });
+    };
+
+    //회원 가입 시도시 보이는 모달
+    const [successModal, setSuccessModal] = useState(false);
+    const [failModal, setFailModal] = useState(false);
+
+    const handleSuccessModal = () => {
+        setSuccessModal(!successModal);
+    };
+
+    const handleFailModal = () => {
+        setFailModal(!failModal);
+    };
+
+    const handleNavigate = () => {
+        setSuccessModal(!successModal);
+        navigate("/login");
+    };
+    return (
+        <>
+            <SignupContainer>
+                <MainText>회원가입</MainText>
+                <SignupFormBox onSubmit={handleSubmit(onSubmit)}>
+                    <InputBox>
+                        <InputText> 이메일</InputText>
+                        <EmailInput type="text" error={errors.email?.message === undefined ? "" : "error"} {...emailRegister} />
+                        <ErrorText>{errors.email?.message}</ErrorText>
+                    </InputBox>
+                    <InputBox>
+                        <InputText> 닉네임</InputText>
+                        <NameInput type="text" error={errors.nickName?.message === undefined ? "" : "error"} {...nickNameRegister} />
+                        <ErrorText>{errors.nickName?.message}</ErrorText>
+                    </InputBox>
+                    <InputBox>
+                        <InputText> 비밀번호</InputText>
+                        <PwInput type="password" error={errors.password?.message === undefined ? "" : "error"} {...passwordRegister} />
+                        <ErrorText>{errors.password?.message}</ErrorText>
+                    </InputBox>
+                    <SingupBtn> 회원가입</SingupBtn>
+                </SignupFormBox>
+                <KalkBtn> 카카오톡으로 회원가입하기</KalkBtn>
+            </SignupContainer>
+            {successModal ? (
+                <ModalBackdrop onClick={handleNavigate}>
+                    <ModalView onClick={(event) => event.stopPropagation()}>
+                        <div className="title">회원가입에 성공하셨습니다.</div>
+                        <CloseIcon onClick={handleNavigate}> 로그인으로 이동</CloseIcon>
+                    </ModalView>
+                </ModalBackdrop>
+            ) : null}
+
+            {failModal ? (
+                <ModalBackdrop onClick={() => setFailModal(false)}>
+                    <ModalView onClick={(event) => event.stopPropagation()}>
+                        <div className="title">아이디 혹은 비밀번호가 중복입니다.</div>
+                        <CloseIcon onClick={handleFailModal}>확인</CloseIcon>
+                    </ModalView>
+                </ModalBackdrop>
+            ) : null}
+        </>
+    );
+};
+
+const ModalBackdrop = styled.div`
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.4);
+`;
+
+const ModalView = styled.div`
+    background-color: whitesmoke;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 380px;
+    height: 200px;
+    margin: 0 auto;
+    border-radius: 30px;
+    font-family: "Nanum Gothic", sans-serif;
+    padding: 20px;
+
+    .title {
+        font-size: 20px;
+        font-weight: var(--font-bold);
+        color: var(--darkgreen);
+        padding-bottom: 10%;
+    }
+`;
+
+const CloseIcon = styled.button`
+ background-color: var(--darkgreen);
+        font-size: 17px;
+        width: 50%;
+        border-radius: 50px;
+
+        :hover {
+            background-color: var(--lightgreen);
+            cursor: pointer;
+            transition: 0.5s;
+`;
 const SignupContainer = styled.div`
     display: flex;
     margin-top: 15px;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    width: 100vw;
-    background-color: #ecf0e6;
+    width: 100%;
+    background-color: var(--lightgreen2);
     min-height: 100vh;
+    padding-top: 90px;
+    padding-bottom: 90px;
+    font-family: "Nanum Gothic";
 `;
 
 const SignupFormBox = styled.form`
@@ -34,21 +191,22 @@ const InputBox = styled.div`
     margin: 8px;
 `;
 
-const MainText = styled.h2`
+const MainText = styled.div`
     font-size: 25px;
     margin: 10px 0px 20px 5px;
     font-family: "Viga";
     font-weight: var(--font-bold);
-    color: #2c483f;
+    color: var(--darkgreen);
 `;
 
-const InputText = styled.label`
+const InputText = styled.div`
     display: flex;
     margin: 10px 0px 5px 5px;
-    font-weight: bold;
-    font-family: "Inter";
-    color: #2c483f;
-    font-size: 20px;
+    .text {
+        color: var(--darkgreen);
+        font-size: 20px;
+        font-weight: bold;
+    }
 `;
 
 const NameInput = styled.input`
@@ -58,12 +216,10 @@ const NameInput = styled.input`
     margin-bottom: 5px;
     padding: 0.5em 0.5em;
     font-size: 18px;
-    border-color: ${(props) => (props.error ? "#de4f54" : "")};
+    border-bottom: 2px solid var(--green);
+    border-color: ${(props) => (props.error ? "#de4f54" : "var(--green)")};
     &:focus {
-        outline: none;
-        border-color: ${(props) => (props.error ? "#de4f54" : "#2c483f")};
-        border-width: 0px;
-        box-shadow: ${(props) => (props.error ? "0 0 0 4px #f7e1e1, 0 0 0 4px #f7e1e1" : "0 0 0 4px #ecf0e6, 0 0 0 4px #ecf0e6")};
+        border-color: ${(props) => (props.error ? "#de4f54" : "var(--lightgreen)")};
     }
 `;
 
@@ -74,12 +230,10 @@ const EmailInput = styled.input`
     margin-bottom: 5px;
     padding: 0.5em 0.5em;
     font-size: 18px;
-    border-color: ${(props) => (props.error ? "#de4f54" : "")};
+    border-bottom: 2px solid var(--green);
+    border-color: ${(props) => (props.error ? "#de4f54" : "var(--green)")};
     &:focus {
-        outline: none;
-        border-color: ${(props) => (props.error ? "#de4f54" : "#2c483f")};
-        border-width: 0px;
-        box-shadow: ${(props) => (props.error ? "0 0 0 4px #f7e1e1, 0 0 0 4px #f7e1e1" : "0 0 0 4px #ecf0e6, 0 0 0 4px #ecf0e6")};
+        border-color: ${(props) => (props.error ? "#de4f54" : "var(--lightgreen)")};
     }
 `;
 
@@ -90,12 +244,10 @@ const PwInput = styled.input`
     margin-bottom: 10px;
     padding: 0.5em 0.5em;
     font-size: 18px;
-    border-color: ${(props) => (props.error ? "#de4f54" : "")};
+    border-bottom: 2px solid var(--green);
+    border-color: ${(props) => (props.error ? "#de4f54" : "var(--green)")};
     &:focus {
-        outline: none;
-        border-color: ${(props) => (props.error ? "#de4f54" : "#2c483f")};
-        border-width: 0px;
-        box-shadow: ${(props) => (props.error ? "0 0 0 4px #f7e1e1, 0 0 0 4px #f7e1e1" : "0 0 0 4px #ecf0e6, 0 0 0 4px #ecf0e6")};
+        border-color: ${(props) => (props.error ? "#de4f54" : "var(--lightgreen)")};
     }
 `;
 
@@ -113,10 +265,11 @@ const SingupBtn = styled.button`
     margin-bottom: 13px;
     width: 335px;
     color: white;
-    background-color: #3f724d;
+    background-color: var(--green);
     border-radius: 10px;
     padding: 10px;
     font-size: 18px;
+    font-family: "Viga";
 `;
 
 const KalkBtn = styled.button`
@@ -124,91 +277,16 @@ const KalkBtn = styled.button`
     justify-content: center;
     margin-top: 30px;
     width: 375px;
-    heigt: 401px;
+
     border-radius: 10px;
     color: white;
     background-color: #ffff;
     border-radius: 10px;
     padding: 10px;
     font-size: 18px;
-    color: #3f724d;
+    color: var(--green);
     border-radius: 7px;
     box-shadow: rgb(0 0 0 / 5%) 0px 0px 4px, rgb(0 0 0 / 5%) 0px 0px 8px, rgb(0 0 0 / 10%) 0px 1px 4px;
 `;
-
-const Signup = () => {
-    const {
-        register,
-        handleSubmit,
-        formState: { errors }
-    } = useForm();
-
-    const navigate = useNavigate();
-
-    const NAME_REGEX = /(?=.*[a-z0-9가-힣]).{2,}/;
-    const EMAIL_REGEX = /^(([^<>()\[\].,;:\s@"]+(\.[^<>()\[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/;
-    const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{4,}/;
-
-    const nameRegister = register("name", {
-        required: { value: true, message: "닉네임을 입력해주세요." },
-        pattern: {
-            value: NAME_REGEX,
-            message: "두글자이상 입력해주세요."
-        }
-    });
-
-    const emailRegister = register("email", {
-        required: { value: true, message: "이메일을 입력해주세요." },
-        pattern: {
-            value: EMAIL_REGEX,
-            message: "이메일 형식에 맞게 입력해주세요."
-        }
-    });
-
-    const passwordRegister = register("password", {
-        required: { value: true, message: "비밀번호를 입력해주세요." },
-        pattern: {
-            value: PASSWORD_REGEX,
-            message: "비밀번호를 입력해주세요."
-        }
-    });
-    // const onSubmit = async (data) => {
-    //     try {
-    //         await axios.post(`http://localhost:3000/signup`, data).then((data) => {
-    //             navigate("/");
-    //             console.log(data);
-    //         });
-    //     } catch (error) {
-    //         console.error(error);
-    //     }
-    // };
-
-    return (
-        <>
-            <SignupContainer>
-                <MainText>일반 회원가입</MainText>
-                <SignupFormBox onSubmit={handleSubmit()}>
-                    <InputBox>
-                        <InputText> 이메일</InputText>
-                        <EmailInput type="text" error={errors.email?.message === undefined ? "" : "error"} {...emailRegister} />
-                        <ErrorText>{errors.email?.message}</ErrorText>
-                    </InputBox>
-                    <InputBox>
-                        <InputText> 닉네임</InputText>
-                        <NameInput type="text" error={errors.name?.message === undefined ? "" : "error"} {...nameRegister} />
-                        <ErrorText>{errors.name?.message}</ErrorText>
-                    </InputBox>
-                    <InputBox>
-                        <InputText> 비밀번호</InputText>
-                        <PwInput type="password" error={errors.password?.message === undefined ? "" : "error"} {...passwordRegister} />
-                        <ErrorText>{errors.password?.message}</ErrorText>
-                    </InputBox>
-                    <SingupBtn> 회원가입</SingupBtn>
-                </SignupFormBox>
-                <KalkBtn> 카카오톡으로 회원가입하기</KalkBtn>
-            </SignupContainer>
-        </>
-    );
-};
 
 export default Signup;

--- a/client/src/pages/Signup.js
+++ b/client/src/pages/Signup.js
@@ -2,11 +2,14 @@ import React from "react";
 import axios from "axios";
 import "../globalStyle.css";
 import { useForm } from "react-hook-form";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
-const Signup = () => {
+const Signup = ({ setIsFooter }) => {
+    useEffect(() => {
+        setIsFooter(false);
+    });
     const {
         register,
         handleSubmit,
@@ -71,6 +74,7 @@ const Signup = () => {
         setSuccessModal(!successModal);
         navigate("/login");
     };
+
     return (
         <>
             <SignupContainer>


### PR DESCRIPTION
## 개요
- 회원가입 시 성공여부에 대한 모달 띄우기
- 로그인 시 Nav (로그인/회원가입) -> (마이페이지/ 로그아웃)으로 변경

## 작업사항
- [Nav.js] 로그인시 로컬스토리지에 저장되어있는 memberId를 확인하여 버튼의 상태를 변경하도록 구현했습니다.
- [Login.js]  입력창 focus가  다른페이지들과 통일성이 떨어져 css 수정하였습니다. 
- [Signup.js] 
-- 입력창 focus가  다른페이지들과 통일성이 떨어져 css 수정하였습니다. 
-- modal을 통해 회원가입 성공여부를 체크할 수 있도록 했습니다. 
-- footer 제거했습니다.
- [App.js] 로그인과 회원가입 페이지에 element로 footer가 들어오지 않아 수정했습니다. 

## 변경사항
- 추후 반응형을 적용하도록 하겠습니다. 

## 기타
- 로컬 스토리지에 있는 loginToken으로 로그인 여부를 확인하고 싶은 데 잘 안되서 memberId로 로그인 여부를 체크하였습니다. 
- 너무 늦어서 죄송합니다. 전문가 페이지는 빠르게 해보겠습니다. 
- commit을 생활화 하겠습니다. 