### PR TITLE
[refator/fe-boards] 태그 미 선택해도 태그가 자리를 차지하는 오류 수정

### DIFF
--- a/client/src/components/boards/BoardDetailQuestion.js
+++ b/client/src/components/boards/BoardDetailQuestion.js
@@ -12,8 +12,6 @@ const BoardDetailQuestion = () => {
     const [board, setBoard] = useRecoilState(boardState);
     const memberId = useRecoilValue(memberIdState);
 
-    console.log(board.createdAt);
-
     // 질문 삭제
     const deleteQuestion = () => {
         axios.delete(`/boards/${board.boardId}`).then((res) => {
@@ -37,11 +35,13 @@ const BoardDetailQuestion = () => {
             {board && (
                 <>
                     <BDQTagsWrapper>
-                        {board.tags.split(",").map((tag, idx) => (
-                            <div key={idx} className="BDQTag">
-                                {tag}
-                            </div>
-                        ))}
+                        {board.tags === ""
+                            ? null
+                            : board.tags.split(",").map((tag, idx) => (
+                                  <div key={idx} className="BDQTag">
+                                      {tag}
+                                  </div>
+                              ))}
                     </BDQTagsWrapper>
 
                     <div className="BDQHeader">

--- a/client/src/components/boards/BoardsMain.js
+++ b/client/src/components/boards/BoardsMain.js
@@ -27,11 +27,7 @@ const BoardsMain = () => {
                     <li key={post.boardId}>
                         <BoardsCardLink to={`/community/${post.boardId}`}>
                             <BoardsTitle>{post.title}</BoardsTitle>
-                            <BoardsTagWrapper>
-                                {post.tags.split(",").map((el, index) => (
-                                    <BoardsTag key={index}>{el}</BoardsTag>
-                                ))}
-                            </BoardsTagWrapper>
+                            <BoardsTagWrapper>{post.tags === "" ? null : post.tags.split(",").map((el, index) => <BoardsTag key={index}>{el}</BoardsTag>)}</BoardsTagWrapper>
                             <BoardsContent>{post.content}</BoardsContent>
                             <BoardsInfo>
                                 {post.voteCount === 0 ? <div>♡ 공감해주세요</div> : <div>♡ {post.voteCount}명이 공감</div>}

--- a/client/src/components/boards/EditBoardMain.js
+++ b/client/src/components/boards/EditBoardMain.js
@@ -20,9 +20,10 @@ const EditBoardMain = () => {
     } = useForm();
 
     // 태그
-    const initialTag = board.tags.split(",");
+    const initialTags = board.tags.split(",");
+    const deleteBlankTags = initialTags.filter((el) => el !== "");
     const tagData = ["일반", "학업", "진로", "취업", "커리어", "가족", "대인관계", "금전", "기타"];
-    const [tags, setTags] = useState([...initialTag]);
+    const [tags, setTags] = useState([...deleteBlankTags]);
 
     // 태그 버튼 이벤트 핸들러
     const handleTags = (e) => {


### PR DESCRIPTION
## 개요
- 태그를 선택하지 않을 때, 태그가 빈 태그로 게시글에서 보이던 문제 수정
<br />

## 작업사항
- [BoardDetailQuestion]: 태그가 빈 문자열이면 태그 컴포넌트가 보이지 않도록 수정하였습니다.
- [BoardsMain]: 태그가 빈 문자열이면 태그 컴포넌트가 보이지 않도록 수정하였습니다.
- [EditBoardMain]: 서버에서 받은 태그 값에서 빈 문자열을 걸러서 tags의 초기값을 넣어주도록 수정하였습니다.
<br />

## 변경사항 (존재한다면)
<br />

## 기타
버그에 신경쓴다고 브랜치명을 깃 컨벤션에 맞지 않게 작성했네요..
다음부터 유의하겠습니다.