### PR TITLE
[feat/fe-boards] 로그인 상태에 따른 권한 부여 (글 등록, 댓글 등록, 공감) 기능 추가, 로그아웃 임시 추가

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -1,28 +1,22 @@
 import styled from "styled-components";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import NavModal from "./NavModal";
-import { memberIdState } from "../states/memberIdState";
 import { useRecoilValue } from "recoil";
+import { memberIdState } from "../states/memberIdState";
+import NavModal from "./NavModal";
 
 const Nav = () => {
-    // 마이페이지 클릭 시 path
-    const memberId = useRecoilValue(memberIdState);
+    const memberId = useRecoilValue(memberIdState); // 마이페이지 path
+    const token = localStorage.getItem("loginToken");
 
-    // local storage login token 확인
-    const [istoken, setIstoken] = useState(false);
+    // 로그아웃 버튼 핸들러
+    const logoutBtnHandle = () => {
+        localStorage.removeItem("memberId");
+        localStorage.removeItem("loginToken");
+        window.location.reload();
+    };
 
-    //memberId의 여부로 Nav버튼 상태 변경
-    useEffect(() => {
-        if (memberId === null) {
-            console.log(memberId);
-        } else {
-            setIstoken(true);
-        }
-    });
-    // !
-
-    // * 모달
+    // 모바일 환경 nav 모달
     const [isOpen, setIsOpen] = useState(false);
     const handleNavModal = () => {
         setIsOpen(!isOpen);
@@ -34,8 +28,6 @@ const Nav = () => {
                 <Link to="/main" className="logo">
                     MENTALTAL
                 </Link>
-                {/* 삭제할 예정 */}
-                {/* <button onClick={handleTest}>0</button> */}
             </NavTitle>
 
             <NavContainer>
@@ -51,28 +43,28 @@ const Nav = () => {
                 <li>
                     <Link to="/counselingcenter">전문기관</Link>
                 </li>
-                {istoken ? (
+                {token ? (
                     <>
                         <li>
-                            <button>
-                                <Link to={`/mypage/${memberId}`}>마이페이지</Link>
-                            </button>
+                            <Link to={`/mypage/${memberId}`}>
+                                <button>마이페이지</button>
+                            </Link>
                         </li>
                         <li>
-                            <button>로그아웃</button>
+                            <button onClick={logoutBtnHandle}>로그아웃</button>
                         </li>
                     </>
                 ) : (
                     <>
                         <li>
-                            <button>
-                                <Link to="/login">로그인</Link>
-                            </button>
+                            <Link to="/login">
+                                <button>로그인</button>
+                            </Link>
                         </li>
                         <li>
-                            <button>
-                                <Link to="/signup">회원가입</Link>
-                            </button>
+                            <Link to="/signup">
+                                <button>회원가입</button>
+                            </Link>
                         </li>
                     </>
                 )}
@@ -80,7 +72,7 @@ const Nav = () => {
 
             <NavMedia>
                 {isOpen ? <i className="fa-solid fa-x" onClick={handleNavModal}></i> : <i className="fa-solid fa-bars" onClick={handleNavModal}></i>}
-                {isOpen ? <NavModal test={test} memberId={memberId} /> : null}
+                {isOpen ? <NavModal memberId={memberId} /> : null}
             </NavMedia>
         </NavWrapper>
     );
@@ -135,15 +127,17 @@ const NavContainer = styled.ul`
     }
 `;
 
-// * 600px 이하 스타일
+// 600px 이하 스타일
 const NavMedia = styled.div`
     display: none;
     position: relative;
+
     i {
         cursor: pointer;
         font-size: 25px;
         color: var(--green);
     }
+
     @media screen and (max-width: 768px) {
         display: block;
     }

--- a/client/src/components/NavModal.js
+++ b/client/src/components/NavModal.js
@@ -1,6 +1,51 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
 
+const NavModal = ({ test, memberId }) => {
+    const token = localStorage.getItem("loginToken");
+
+    // 로그아웃 버튼 핸들러
+    const logoutBtnHandle = () => {
+        localStorage.removeItem("memberId");
+        localStorage.removeItem("loginToken");
+        window.location.reload();
+    };
+
+    return (
+        <NavModalWrapper>
+            <li>
+                <Link to="/community">커뮤니티</Link>
+            </li>
+            <li>
+                <Link to="/selfcheck">자가진단</Link>
+            </li>
+            <li>
+                <Link to="/counselor">전문가</Link>
+            </li>
+            <li>
+                <Link to="/counselingcenter">전문기관</Link>
+            </li>
+            {token ? (
+                <>
+                    <li>
+                        <Link to={`/mypage/${memberId}`}>마이페이지</Link>
+                    </li>
+                    <li onClick={logoutBtnHandle}>로그아웃</li>
+                </>
+            ) : (
+                <>
+                    <li>
+                        <Link to="/login">로그인</Link>
+                    </li>
+                    <li>
+                        <Link to="/signup">회원가입</Link>
+                    </li>
+                </>
+            )}
+        </NavModalWrapper>
+    );
+};
+
 const NavModalWrapper = styled.ul`
     width: 150px;
 
@@ -25,43 +70,13 @@ const NavModalWrapper = styled.ul`
 
     li {
         padding: 10px;
+        cursor: pointer;
+    }
+
+    li:hover {
+        font-weight: 900;
+        transition: 0.5s;
     }
 `;
-
-const NavModal = ({ test, memberId }) => {
-    return (
-        <NavModalWrapper>
-            <li>
-                <Link to="/community">커뮤니티</Link>
-            </li>
-            <li>
-                <Link to="/selfcheck">자가진단</Link>
-            </li>
-            <li>
-                <Link to="/counselors">전문가</Link>
-            </li>
-            <li>
-                <Link to="/counselingcenter">전문기관</Link>
-            </li>
-            {test ? (
-                <>
-                    <li>
-                        <Link to={`/mypage/${memberId}`}>마이페이지</Link>
-                    </li>
-                    <li>로그아웃</li>
-                </>
-            ) : (
-                <>
-                    <li>
-                        <Link to="/login">로그인</Link>
-                    </li>
-                    <li>
-                        <Link to="/signup">회원가입</Link>
-                    </li>
-                </>
-            )}
-        </NavModalWrapper>
-    );
-};
 
 export default NavModal;

--- a/client/src/components/boards/BoardDetailAnswer.js
+++ b/client/src/components/boards/BoardDetailAnswer.js
@@ -6,7 +6,6 @@ import { dateCalculation } from "./dateCalculation";
 import { useRecoilValue } from "recoil";
 import { memberIdState } from "../../states";
 
-// ! 전문가 회원 구현되면  전문가만 따로 표시하도록 수정
 const BoardDetailAnswer = ({ answer }) => {
     const url = "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080";
     const [isEdit, setIsEdit] = useState(false);
@@ -27,7 +26,7 @@ const BoardDetailAnswer = ({ answer }) => {
     // 답글 수정 요청 함수
     const editComment = (data) => {
         axios
-            .patch(`${url}/comments/${answer.commentId}`, data)
+            .patch(`/comments/${answer.commentId}`, data)
             .then((res) => {
                 window.location.reload();
             })
@@ -39,7 +38,7 @@ const BoardDetailAnswer = ({ answer }) => {
     // 답글 삭제 요청 함수
     const deleteComment = () => {
         axios
-            .delete(`${url}/comments/${answer.commentId}`)
+            .delete(`/comments/${answer.commentId}`)
             .then((res) => {
                 window.location.reload();
             })
@@ -49,7 +48,7 @@ const BoardDetailAnswer = ({ answer }) => {
     // 공감 버튼
     const heartBtnHandle = () => {
         axios
-            .post(`${url}/comments/${answer.commentId}/votes?memberId=${memberId}&voteCheck=true`)
+            .post(`/comments/${answer.commentId}/votes?memberId=${memberId}&voteCheck=true`)
             .then((res) => {
                 window.location.reload();
             })

--- a/client/src/components/boards/BoardDetailAnswer.js
+++ b/client/src/components/boards/BoardDetailAnswer.js
@@ -6,10 +6,11 @@ import { dateCalculation } from "./dateCalculation";
 import { useRecoilValue } from "recoil";
 import { memberIdState } from "../../states";
 
-const BoardDetailAnswer = ({ answer }) => {
+const BoardDetailAnswer = ({ answer, setIsLogin }) => {
     const url = "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080";
     const [isEdit, setIsEdit] = useState(false);
     const memberId = useRecoilValue(memberIdState);
+    const token = localStorage.getItem("loginToken");
 
     // 답글 수정 form
     const {
@@ -47,12 +48,18 @@ const BoardDetailAnswer = ({ answer }) => {
 
     // 공감 버튼
     const heartBtnHandle = () => {
-        axios
-            .post(`/comments/${answer.commentId}/votes?memberId=${memberId}&voteCheck=true`)
-            .then((res) => {
-                window.location.reload();
-            })
-            .catch((err) => console.log(err));
+        if (token) {
+            setIsLogin(false);
+
+            axios
+                .post(`/comments/${answer.commentId}/votes?memberId=${memberId}&voteCheck=true`)
+                .then((res) => {
+                    window.location.reload();
+                })
+                .catch((err) => console.log(err));
+        } else {
+            setIsLogin(true);
+        }
     };
 
     return (

--- a/client/src/components/boards/BoardDetailAnswer.js
+++ b/client/src/components/boards/BoardDetailAnswer.js
@@ -27,7 +27,7 @@ const BoardDetailAnswer = ({ answer }) => {
     // 답글 수정 요청 함수
     const editComment = (data) => {
         axios
-            .patch(`/comments/${answer.commentId}`, data)
+            .patch(`${url}/comments/${answer.commentId}`, data)
             .then((res) => {
                 window.location.reload();
             })
@@ -39,7 +39,7 @@ const BoardDetailAnswer = ({ answer }) => {
     // 답글 삭제 요청 함수
     const deleteComment = () => {
         axios
-            .delete(`/comments/${answer.commentId}`)
+            .delete(`${url}/comments/${answer.commentId}`)
             .then((res) => {
                 window.location.reload();
             })
@@ -49,7 +49,7 @@ const BoardDetailAnswer = ({ answer }) => {
     // 공감 버튼
     const heartBtnHandle = () => {
         axios
-            .post(`/comments/${answer.commentId}/votes?memberId=${memberId}&voteCheck=true`)
+            .post(`${url}/comments/${answer.commentId}/votes?memberId=${memberId}&voteCheck=true`)
             .then((res) => {
                 window.location.reload();
             })

--- a/client/src/components/boards/BoardDetailAnswerCreate.js
+++ b/client/src/components/boards/BoardDetailAnswerCreate.js
@@ -4,11 +4,11 @@ import { useForm } from "react-hook-form";
 import { useRecoilValue } from "recoil";
 import { boardState, memberIdState } from "../../states";
 
-// ! 나중에 서버 연결시 데이터 받아서 랜더링되도록 수정할 것
-const BoardDetailAnswerCreate = () => {
+const BoardDetailAnswerCreate = ({ setIsLogin }) => {
+    const url = "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080";
     const board = useRecoilValue(boardState);
     const memberId = useRecoilValue(memberIdState);
-    const url = "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080";
+    const token = localStorage.getItem("loginToken");
 
     // 답글 등록 form
     const {
@@ -19,12 +19,18 @@ const BoardDetailAnswerCreate = () => {
 
     // 답글 등록 요청 함수
     const postComment = (data) => {
-        axios
-            .post(`/comments`, data)
-            .then((res) => {
-                window.location.reload();
-            })
-            .catch((err) => console.log(err));
+        if (token) {
+            setIsLogin(false);
+
+            axios
+                .post(`/comments`, data)
+                .then((res) => {
+                    window.location.reload();
+                })
+                .catch((err) => console.log(err));
+        } else {
+            setIsLogin(true);
+        }
     };
 
     return (

--- a/client/src/components/boards/BoardDetailAnswerList.js
+++ b/client/src/components/boards/BoardDetailAnswerList.js
@@ -3,12 +3,12 @@ import { useRecoilValue } from "recoil";
 import { answerState } from "../../states";
 import BoardDetailAnswer from "./BoardDetailAnswer";
 
-const BoardDetailAnswerList = () => {
+const BoardDetailAnswerList = ({ setIsLogin }) => {
     const answers = useRecoilValue(answerState);
 
     return (
         <>
-            <BDAWrapper>{answers && answers.map((answer, idx) => <BoardDetailAnswer answer={answer} key={idx} />)}</BDAWrapper>
+            <BDAWrapper>{answers && answers.map((answer, idx) => <BoardDetailAnswer answer={answer} key={idx} setIsLogin={setIsLogin} />)}</BDAWrapper>
         </>
     );
 };

--- a/client/src/components/boards/BoardDetailQuestion.js
+++ b/client/src/components/boards/BoardDetailQuestion.js
@@ -6,11 +6,12 @@ import { boardState, memberIdState } from "../../states/";
 import { dateCalculation } from "./dateCalculation";
 
 // component
-const BoardDetailQuestion = () => {
+const BoardDetailQuestion = ({ setIsLogin }) => {
     const url = "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080";
     const navigate = useNavigate();
     const [board, setBoard] = useRecoilState(boardState);
     const memberId = useRecoilValue(memberIdState);
+    const token = localStorage.getItem("loginToken");
 
     // 질문 삭제
     const deleteQuestion = () => {
@@ -22,6 +23,16 @@ const BoardDetailQuestion = () => {
 
     // 공감 버튼
     const heartBtnHandle = () => {
+        if (token) {
+            setIsLogin(false);
+            postHeart();
+        } else {
+            setIsLogin(true);
+        }
+    };
+
+    // 공감 서버 요청 함수
+    const postHeart = () => {
         axios
             .post(`/boards/${board.boardId}/votes?memberId=${memberId}&voteCheck=true`)
             .then((res) => {

--- a/client/src/components/boards/BoardModal.js
+++ b/client/src/components/boards/BoardModal.js
@@ -8,14 +8,17 @@ const BoardModal = ({ setIsLogin }) => {
         <BMWrapper onClick={() => setIsLogin(false)}>
             <BMContainer>
                 <div>로그인 후 이용해주세요.</div>
-                <button
-                    onClick={() => {
-                        navigate("/login");
-                        setIsLogin(false);
-                    }}
-                >
-                    바로가기
-                </button>
+                <BMBtnContainer>
+                    <button
+                        onClick={() => {
+                            navigate("/login");
+                            setIsLogin(false);
+                        }}
+                    >
+                        바로가기
+                    </button>
+                    <button onClick={() => setIsLogin(false)}>취소</button>
+                </BMBtnContainer>
             </BMContainer>
         </BMWrapper>
     );
@@ -56,9 +59,21 @@ const BMContainer = styled.div`
         font-weight: var(--font-bold);
         margin-bottom: 15px;
     }
+`;
+
+const BMBtnContainer = styled.div`
+    display: flex;
+    gap: 15px;
 
     button {
+        background-color: var(--darkgreen);
         font-family: "Nanum Gothic", sans-serif;
+
+        :hover {
+            background-color: var(--lightgreen);
+            cursor: pointer;
+            transition: 0.5s;
+        }
     }
 `;
 

--- a/client/src/components/boards/BoardModal.js
+++ b/client/src/components/boards/BoardModal.js
@@ -1,0 +1,67 @@
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+
+const BoardModal = ({ setIsLogin }) => {
+    const navigate = useNavigate();
+
+    return (
+        <BMWrapper onClick={() => setIsLogin(false)}>
+            <BMContainer>
+                <div>로그인 후 이용해주세요.</div>
+                <button
+                    onClick={() => {
+                        navigate("/login");
+                        setIsLogin(false);
+                    }}
+                >
+                    바로가기
+                </button>
+            </BMContainer>
+        </BMWrapper>
+    );
+};
+
+const BMWrapper = styled.div`
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+
+    display: flex;
+    justify-content: center;
+`;
+
+const BMContainer = styled.div`
+    position: absolute;
+    top: 300px;
+
+    width: 280px;
+    height: 150px;
+    padding: 20px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    border-radius: 30px;
+    background-color: white;
+
+    div {
+        color: var(--darkgreen);
+        font-family: "Nanum Gothic", sans-serif;
+        font-weight: var(--font-bold);
+        margin-bottom: 15px;
+    }
+
+    button {
+        font-family: "Nanum Gothic", sans-serif;
+    }
+`;
+
+export default BoardModal;

--- a/client/src/components/boards/BoardModal.js
+++ b/client/src/components/boards/BoardModal.js
@@ -34,12 +34,10 @@ const BMWrapper = styled.div`
 
     display: flex;
     justify-content: center;
+    align-items: center;
 `;
 
 const BMContainer = styled.div`
-    position: absolute;
-    top: 300px;
-
     width: 280px;
     height: 150px;
     padding: 20px;

--- a/client/src/components/boards/BoardsHeader.js
+++ b/client/src/components/boards/BoardsHeader.js
@@ -1,7 +1,22 @@
 import styled from "styled-components";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
+import { loginState } from "../../states";
 
 const BoardsHeader = () => {
+    const navigate = useNavigate();
+    const token = localStorage.getItem("loginToken");
+    const setIsLogIn = useSetRecoilState(loginState);
+
+    const createBoardLinkBtnHandle = () => {
+        if (token) {
+            setIsLogIn(false);
+            navigate("/write");
+        } else {
+            setIsLogIn(true);
+        }
+    };
+
     return (
         <BoardsHeaderWrapper>
             <BoardsHeaderTitle>
@@ -10,8 +25,8 @@ const BoardsHeader = () => {
                 <div>나와 비슷한 고민을 가진 사람들과 마음속 이야기를 나누어 보세요.</div>
             </BoardsHeaderTitle>
 
-            <BoardsLink to="/write">
-                <button>
+            <BoardsLink>
+                <button onClick={createBoardLinkBtnHandle}>
                     고민 작성하기 <i className="fa-solid fa-chevron-right"></i>
                 </button>
             </BoardsLink>
@@ -81,7 +96,7 @@ const BoardsHeaderTitle = styled.div`
     }
 `;
 
-const BoardsLink = styled(Link)`
+const BoardsLink = styled.div`
     button {
         font-family: "Nanum Gothic", sans-serif;
         border-radius: 30px;

--- a/client/src/components/boards/BoardsHeader.js
+++ b/client/src/components/boards/BoardsHeader.js
@@ -1,19 +1,16 @@
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
-import { useSetRecoilState } from "recoil";
-import { loginState } from "../../states";
 
-const BoardsHeader = () => {
+const BoardsHeader = ({ setIsLogin }) => {
     const navigate = useNavigate();
     const token = localStorage.getItem("loginToken");
-    const setIsLogIn = useSetRecoilState(loginState);
 
     const createBoardLinkBtnHandle = () => {
         if (token) {
-            setIsLogIn(false);
+            setIsLogin(false);
             navigate("/write");
         } else {
-            setIsLogIn(true);
+            setIsLogin(true);
         }
     };
 

--- a/client/src/components/boards/CreateBoardMain.js
+++ b/client/src/components/boards/CreateBoardMain.js
@@ -50,7 +50,6 @@ const CreateBoardMain = () => {
                 onSubmit={handleSubmit((data) => {
                     data.tags = tags.join();
                     data.memberId = memberId;
-                    console.log(tags);
                     postBoard(data);
                 })}
             >

--- a/client/src/components/boards/EditBoardMain.js
+++ b/client/src/components/boards/EditBoardMain.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import axios from "axios";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { useRecoilState, useRecoilValue } from "recoil";
@@ -31,7 +31,6 @@ const EditBoardMain = () => {
 
         if (tags.includes(str)) {
             const result = tags.filter((el) => el !== `${str}`);
-            console.log(tags);
             return setTags(result);
         }
 

--- a/client/src/components/self/SelfCheckError.js
+++ b/client/src/components/self/SelfCheckError.js
@@ -1,12 +1,8 @@
 import styled from "styled-components";
-import { useSetRecoilState } from "recoil";
-import { selfCheckErrorState } from "../../states";
 
-const SelfCheckError = () => {
-    const setError = useSetRecoilState(selfCheckErrorState);
-
+const SelfCheckError = ({ setIsAllSelect }) => {
     const closeBtnHandle = () => {
-        setError(false);
+        setIsAllSelect(false);
     };
 
     return (

--- a/client/src/components/self/SelfCheckMain.js
+++ b/client/src/components/self/SelfCheckMain.js
@@ -98,7 +98,7 @@ const SelfCheckMain = () => {
                     ) : (
                         <div className="none">메뉴에서 자가진단할 테스트를 선택해주세요.</div>
                     )}
-                    {isAllSelect ? <SelfCheckError /> : null}
+                    {isAllSelect ? <SelfCheckError setIsAllSelect={setIsAllSelect} /> : null}
                 </SCTableWrapper>
 
                 <SCTableResultBtn>{accordionIndex === 0 || accordionIndex === 1 ? <button onClick={calculationSelfCheck}>결과보기</button> : null}</SCTableResultBtn>

--- a/client/src/components/self/SelfCheckMain.js
+++ b/client/src/components/self/SelfCheckMain.js
@@ -1,17 +1,16 @@
 import styled from "styled-components";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
-import { selfCheckState, selfCheckErrorState } from "../../states";
+import { selfCheckState } from "../../states";
 import SelfCheckTable from "./SelfCheckTable";
 import { depression, stress } from "./selfCheckDummy";
 import SelfCheckError from "./SelfCheckError";
 
 const SelfCheckMain = () => {
-    const [result, setResult] = useRecoilState(selfCheckState);
-    const [error, setError] = useRecoilState(selfCheckErrorState);
     const navigate = useNavigate();
-
+    const [isAllSelect, setIsAllSelect] = useState(false);
+    const [result, setResult] = useRecoilState(selfCheckState);
     const [isOn, setIsOn] = useState(false);
     const [accordionIndex, setAccordionIndex] = useState(null);
     const [accordionData] = useState([
@@ -24,10 +23,6 @@ const SelfCheckMain = () => {
             name: "스트레스",
         },
     ]);
-
-    useEffect(() => {
-        setError(false);
-    }, []);
 
     const accordionMainBoxBtnHandle = (e, idx) => {
         setAccordionIndex(idx);
@@ -53,11 +48,11 @@ const SelfCheckMain = () => {
         const stressStandard = result.type === "스트레스" && check === 15;
 
         if (depressionStandard || stressStandard) {
-            setError(!error);
+            setIsAllSelect(!isAllSelect);
             navigate("/selfcheckresult");
         }
 
-        setError(!error);
+        setIsAllSelect(!isAllSelect);
     };
 
     return (
@@ -103,7 +98,7 @@ const SelfCheckMain = () => {
                     ) : (
                         <div className="none">메뉴에서 자가진단할 테스트를 선택해주세요.</div>
                     )}
-                    {error ? <SelfCheckError /> : null}
+                    {isAllSelect ? <SelfCheckError /> : null}
                 </SCTableWrapper>
 
                 <SCTableResultBtn>{accordionIndex === 0 || accordionIndex === 1 ? <button onClick={calculationSelfCheck}>결과보기</button> : null}</SCTableResultBtn>

--- a/client/src/pages/BoardDetail.js
+++ b/client/src/pages/BoardDetail.js
@@ -34,7 +34,7 @@ const BoardDetail = ({ setIsFooter }) => {
         <BoardDetailWrapper>
             <BoardDetailQuestion setIsLogin={setIsLogin} />
             {/* {board.commentCount === 0 ? null : <BoardDetailAnswerList />} */}
-            <BoardDetailAnswerList />
+            <BoardDetailAnswerList setIsLogin={setIsLogin} />
             <BoardDetailAnswerCreate setIsLogin={setIsLogin} />
             {isLogin ? <BoardModal setIsLogin={setIsLogin} /> : null}
         </BoardDetailWrapper>

--- a/client/src/pages/BoardDetail.js
+++ b/client/src/pages/BoardDetail.js
@@ -1,18 +1,22 @@
 import { useParams } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import axios from "axios";
 import { useSetRecoilState, useRecoilState } from "recoil";
 import { boardState, answerState } from "../states";
+
+// components
 import BoardDetailQuestion from "../components/boards/BoardDetailQuestion";
 import BoardDetailAnswerList from "../components/boards/BoardDetailAnswerList";
 import BoardDetailAnswerCreate from "../components/boards/BoardDetailAnswerCreate";
+import BoardModal from "../components/boards/BoardModal";
 
 const BoardDetail = ({ setIsFooter }) => {
     const { id } = useParams();
     const url = "http://ec2-3-36-53-155.ap-northeast-2.compute.amazonaws.com:8080";
     const [board, setBoard] = useRecoilState(boardState);
     const setAnswer = useSetRecoilState(answerState);
+    const [isLogin, setIsLogin] = useState(false);
 
     useEffect(() => {
         setIsFooter(true);
@@ -28,10 +32,11 @@ const BoardDetail = ({ setIsFooter }) => {
 
     return (
         <BoardDetailWrapper>
-            <BoardDetailQuestion></BoardDetailQuestion>
+            <BoardDetailQuestion setIsLogin={setIsLogin} />
             {/* {board.commentCount === 0 ? null : <BoardDetailAnswerList />} */}
             <BoardDetailAnswerList />
             <BoardDetailAnswerCreate />
+            {isLogin ? <BoardModal setIsLogin={setIsLogin} /> : null}
         </BoardDetailWrapper>
     );
 };
@@ -47,6 +52,8 @@ const BoardDetailWrapper = styled.div`
     flex-direction: column;
     align-items: center;
     gap: 40px;
+
+    position: relative; // modal 위치
 `;
 
 export default BoardDetail;

--- a/client/src/pages/BoardDetail.js
+++ b/client/src/pages/BoardDetail.js
@@ -35,7 +35,7 @@ const BoardDetail = ({ setIsFooter }) => {
             <BoardDetailQuestion setIsLogin={setIsLogin} />
             {/* {board.commentCount === 0 ? null : <BoardDetailAnswerList />} */}
             <BoardDetailAnswerList />
-            <BoardDetailAnswerCreate />
+            <BoardDetailAnswerCreate setIsLogin={setIsLogin} />
             {isLogin ? <BoardModal setIsLogin={setIsLogin} /> : null}
         </BoardDetailWrapper>
     );

--- a/client/src/pages/Boards.js
+++ b/client/src/pages/Boards.js
@@ -1,19 +1,14 @@
 import styled from "styled-components";
 import { useEffect } from "react";
-import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 
 // components
 import BoardsHeader from "../components/boards/BoardsHeader";
 import BoardsMain from "../components/boards/BoardsMain";
+import BoardModal from "../components/boards/BoardModal";
 
 const Boards = ({ setIsFooter }) => {
     const [isLogin, setIsLogin] = useState(false);
-    const navigate = useNavigate();
-
-    const modalHandle = () => {
-        setIsLogin(!isLogin);
-    };
 
     useEffect(() => {
         setIsFooter(true);
@@ -23,74 +18,14 @@ const Boards = ({ setIsFooter }) => {
         <BoardsWrapper>
             <BoardsHeader setIsLogin={setIsLogin} />
             <BoardsMain />
-
-            {isLogin ? (
-                <BoardsModalWrapper onClick={modalHandle}>
-                    <BoardsModalContainer>
-                        <div>로그인 후 이용해주세요.</div>
-                        <button
-                            onClick={() => {
-                                navigate("/login");
-                                setIsLogin(false);
-                            }}
-                        >
-                            바로가기
-                        </button>
-                    </BoardsModalContainer>
-                </BoardsModalWrapper>
-            ) : null}
+            {isLogin ? <BoardModal setIsLogin={setIsLogin} /> : null}
         </BoardsWrapper>
     );
 };
 
 const BoardsWrapper = styled.div`
     margin-top: 65px;
-
-    position: relative;
-`;
-
-// ------------- modal ------------- //
-const BoardsModalWrapper = styled.div`
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.4);
-
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-
-    display: flex;
-    justify-content: center;
-`;
-
-const BoardsModalContainer = styled.div`
-    position: absolute;
-    top: 300px;
-
-    width: 280px;
-    height: 150px;
-    padding: 20px;
-
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-
-    border-radius: 30px;
-    background-color: white;
-
-    div {
-        color: var(--darkgreen);
-        font-family: "Nanum Gothic", sans-serif;
-        font-weight: var(--font-bold);
-        margin-bottom: 15px;
-    }
-
-    button {
-        font-family: "Nanum Gothic", sans-serif;
-    }
+    position: relative; // modal 위치
 `;
 
 export default Boards;

--- a/client/src/pages/Boards.js
+++ b/client/src/pages/Boards.js
@@ -1,23 +1,96 @@
 import styled from "styled-components";
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useState } from "react";
+
+// components
 import BoardsHeader from "../components/boards/BoardsHeader";
 import BoardsMain from "../components/boards/BoardsMain";
 
 const Boards = ({ setIsFooter }) => {
+    const [isLogin, setIsLogin] = useState(false);
+    const navigate = useNavigate();
+
+    const modalHandle = () => {
+        setIsLogin(!isLogin);
+    };
+
     useEffect(() => {
         setIsFooter(true);
     });
 
     return (
         <BoardsWrapper>
-            <BoardsHeader />
+            <BoardsHeader setIsLogin={setIsLogin} />
             <BoardsMain />
+
+            {isLogin ? (
+                <BoardsModalWrapper onClick={modalHandle}>
+                    <BoardsModalContainer>
+                        <div>로그인 후 이용해주세요.</div>
+                        <button
+                            onClick={() => {
+                                navigate("/login");
+                                setIsLogin(false);
+                            }}
+                        >
+                            바로가기
+                        </button>
+                    </BoardsModalContainer>
+                </BoardsModalWrapper>
+            ) : null}
         </BoardsWrapper>
     );
 };
 
 const BoardsWrapper = styled.div`
     margin-top: 65px;
+
+    position: relative;
+`;
+
+// ------------- modal ------------- //
+const BoardsModalWrapper = styled.div`
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+
+    display: flex;
+    justify-content: center;
+`;
+
+const BoardsModalContainer = styled.div`
+    position: absolute;
+    top: 300px;
+
+    width: 280px;
+    height: 150px;
+    padding: 20px;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    border-radius: 30px;
+    background-color: white;
+
+    div {
+        color: var(--darkgreen);
+        font-family: "Nanum Gothic", sans-serif;
+        font-weight: var(--font-bold);
+        margin-bottom: 15px;
+    }
+
+    button {
+        font-family: "Nanum Gothic", sans-serif;
+    }
 `;
 
 export default Boards;

--- a/client/src/states/index.js
+++ b/client/src/states/index.js
@@ -3,4 +3,3 @@ export * from "./answerState";
 export * from "./memberIdState";
 export * from "./selfCheckState";
 export * from "./selfCheckErrorState";
-export * from "./loginState";

--- a/client/src/states/index.js
+++ b/client/src/states/index.js
@@ -2,4 +2,3 @@ export * from "./boardState";
 export * from "./answerState";
 export * from "./memberIdState";
 export * from "./selfCheckState";
-export * from "./selfCheckErrorState";

--- a/client/src/states/index.js
+++ b/client/src/states/index.js
@@ -3,3 +3,4 @@ export * from "./answerState";
 export * from "./memberIdState";
 export * from "./selfCheckState";
 export * from "./selfCheckErrorState";
+export * from "./loginState";

--- a/client/src/states/loginState.js
+++ b/client/src/states/loginState.js
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const loginState = atom({
+    key: "loginState",
+    default: false,
+});

--- a/client/src/states/loginState.js
+++ b/client/src/states/loginState.js
@@ -1,6 +1,0 @@
-import { atom } from "recoil";
-
-export const loginState = atom({
-    key: "loginState",
-    default: false,
-});

--- a/client/src/states/selfCheckErrorState.js
+++ b/client/src/states/selfCheckErrorState.js
@@ -1,6 +1,0 @@
-import { atom } from "recoil";
-
-export const selfCheckErrorState = atom({
-    key: "selfCheckErrorState",
-    default: false,
-});


### PR DESCRIPTION
## 개요
비로그인 상태에서 새 글 등록 / 댓글 등록 / 공감 (질문, 댓글)을 할 경우 로그인 후 시도해달라는 모달이 뜨도록 추가하였습니다.
로그아웃 기능을 임시로 추가하였습니다.
<br />

## 작업사항
- [BoardDetailAnswer]: 공감 버튼 클릭시 로그인 상태인지 확인 후 로그인 상태라면 서버에 요청을, 아니라면 모달이 뜨도록 수정하였습니다.
- [BoardDetailAnswerCreate]: 댓글 버튼 클릭시 로그인 상태인지 확인 후 로그인 상태라면 서버에 요청을, 아니라면 모달이 뜨도록 수정하였습니다.
- [BoardDetailQuestion]: 공감 버튼 클릭시 로그인 상태인지 확인 후 로그인 상태라면 서버에 요청을, 아니라면 모달이 뜨도록 수정하였습니다.
- [BoardModal]: 비로그인 상태시 띄워지는 모달 컴포넌트입니다. 공통적으로 사용되어 재사용 컴포넌트로 만들었습니다.
- [BoardHeader]: 글 등록 버튼 클릭시 로그인 상태인지 확인 후 로그인 상태라면 글 등록 페이지로, 아니라면 모달이 뜨도록 수정하였습니다.
- [BoardDetail]: 모달관련하여 코드가 추가되었습니다.
- [Boards]: 모달관련하여 코드가 추가되었습니다.
- [Nav]: 로그아웃 기능이 임시로 추가되었으며, 가끔씩 로그인 버튼이 눌리지 않았던게 태그 순서 문제 인 것 같아 수정하였습니다.
- [NavModal]: 로그아웃 기능이 임시로 추가되었으며 css 코드가 수정되었습니다.
<br />

## 변경사항 (존재한다면)
- [BoardDetailAnswerList]: props전달로 인한 수정
- [CreateBoardMain]: 필요없는 코드 삭제
- [EditBoardMain]: 필요없는 코드 삭제
- [SelfCheckError]: 의미에 맞도록 변수명 변경
- [SelfCheckMain]: 변수명 변경, recoil로 관리되던 상태를 useState로 변경하였습니다.
- [state/index.js]: 필요없어진 파일 삭제로 인한 코드 수정
<br />

## 기타