### PR TITLE
[fix/fe] boardsMain 스크롤 이벤트 삭제, 로딩 컴포넌트 높이 변경

### DIFF
--- a/client/src/components/boards/BoardsMain.js
+++ b/client/src/components/boards/BoardsMain.js
@@ -42,7 +42,6 @@ const BoardsMain = () => {
 
     // 게시판 목록 데이터 요청 함수
     useEffect(() => {
-        window.scrollTo(0, 0);
         setLoading(true);
 
         setTimeout(() => {

--- a/client/src/components/boards/BoardsMain.js
+++ b/client/src/components/boards/BoardsMain.js
@@ -123,7 +123,7 @@ const BoardsMainWrapper = styled.main`
 
 const BoardsMainLoading = styled.div`
     width: 100%;
-    height: 90vh;
+    height: 50vh;
 
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## 개요
필터링 버튼 클릭할 때 마다 위로 스크롤 해서 새로고침되는게 사용자 입장에서 좋다고 느껴지지 않아 삭제합니다.
로딩 컴포넌트의 높이가 너무 높아 모바일 환경이용시 보이지 않아 높이를 조절하였습니다.

## 작업사항

## 변경사항 (존재한다면)

## 기타