### PR TITLE
[Fix/fe-main] 메인 페이지 캐러셀 반응형 오류 수정

### DIFF
--- a/client/src/components/main/Carousel.js
+++ b/client/src/components/main/Carousel.js
@@ -36,28 +36,26 @@ export default function Carousel() {
         <>
             <Container>
                 <Swiper
-                    // slidesPerView={4}
                     breakpoints={{
-                        // when window width is >= 640px
                         320: {
                             width: 320,
                             slidesPerView: 1,
                             spaceBetween: 30,
+                            slidesPerGroup: 1,
                         },
-                        // when window width is >= 768px
-                        600: {
-                            width: 600,
+                        809: {
+                            width: 809,
                             slidesPerView: 2,
-                            spaceBetween: 30,
+                            spaceBetween: -150,
+                            slidesPerGroup: 2,
                         },
                         1200: {
                             width: 1200,
                             slidesPerView: 4,
                             spaceBetween: 10,
+                            slidesPerGroup: 4,
                         },
                     }}
-                    // spaceBetween={-30}
-                    slidesPerGroup={4}
                     loop={false}
                     loopFillGroupWithBlank={true}
                     navigation={true}


### PR DESCRIPTION
## 개요
메인 페이지 슬라이드에서 화면을 크게 줄였을 경우 게시글 몇 개를 건너뛰고 다음으로 그룹핑된 게시글을 보여주는 오류가 있어 수정했습니다.

## 작업사항
## 변경사항 (존재한다면)
## 기타