### PR TITLE
[Fix/fe-mainpage] 메인 페이지 헤더에 소개 페이지 이동 버튼 추가, 메인 페이지 반응형 UI 재조정, 전문가 페이지 헤더 UI 조정

### DIFF
--- a/client/src/components/counselor/CounselorHeader.js
+++ b/client/src/components/counselor/CounselorHeader.js
@@ -7,8 +7,8 @@ const CounselorHeader = () => {
         <BoardsHeaderWrapper>
             <CounselorTitle>
                 <div className="logo">MENTALTAL 전문가</div>
-                <p>고민을 나눌 수 있는 전문가를 소개하는 공간입니다.</p>
-                <p>전문가는 언제든 당신의 고민을 듣고 조언해줄 수 있습니다.</p>
+                <p>전문가의 도움이 필요하신가요?</p>
+                <p>MENTALTAL 전문가 프로필을 확인하고 나에게 딱 맞는 전문 상담을 받아보세요.</p>
             </CounselorTitle>
         </BoardsHeaderWrapper>
     );
@@ -21,7 +21,7 @@ const BoardsHeaderWrapper = styled.header`
     padding: 60px 100px;
     background-color: var(--lightgreen2);
     justify-content: space-between;
-    align-items: flex-end;
+    align-items: center;
     font-family: "Nanum Gothic", sans-serif;
 `;
 

--- a/client/src/components/counselor/CounselorHeader.js
+++ b/client/src/components/counselor/CounselorHeader.js
@@ -22,6 +22,7 @@ const BoardsHeaderWrapper = styled.header`
     background-color: var(--lightgreen2);
     justify-content: space-between;
     align-items: flex-end;
+    font-family: "Nanum Gothic", sans-serif;
 `;
 
 const CounselorTitle = styled.div`
@@ -34,7 +35,7 @@ const CounselorTitle = styled.div`
     & :nth-child(1) {
         font-size: 40px;
         font-weight: 900;
-        margin-bottom: 10px;
+        margin-bottom: 12px;
     }
 
     & :not(:nth-child(1)) {

--- a/client/src/components/counselor/CounselorHeader.js
+++ b/client/src/components/counselor/CounselorHeader.js
@@ -31,11 +31,12 @@ const CounselorTitle = styled.div`
     justify-content: flex-end;
     gap: 10px;
     color: var(--darkgreen);
+    line-height: 130%;
 
     & :nth-child(1) {
         font-size: 40px;
         font-weight: 900;
-        margin-bottom: 12px;
+        margin-bottom: 30px;
     }
 
     & :not(:nth-child(1)) {

--- a/client/src/components/counselor/Counseloritem.js
+++ b/client/src/components/counselor/Counseloritem.js
@@ -34,6 +34,7 @@ const Counselor = styled.div`
     align-content: center;
     flex-wrap: wrap;
     flex-direction: column;
+    font-family: "Nanum Gothic", sans-serif;
 
     .imgcontainer {
         border-radius: 10%;

--- a/client/src/components/intro/IntroResponsive.js
+++ b/client/src/components/intro/IntroResponsive.js
@@ -83,7 +83,6 @@ const LeftContainer = styled.div`
     /* Nav height */
     padding-top: 65px;
 
-    //420
     @media screen and (max-width: 521px) {
         padding: 0;
         align-items: center;

--- a/client/src/components/main/Carousel.js
+++ b/client/src/components/main/Carousel.js
@@ -6,15 +6,12 @@ import Preview from "./Preview";
 import { useEffect, useState } from "react";
 import axios from "axios";
 
+// Swiper
 import { Swiper, SwiperSlide } from "swiper/react";
-
-// Import Swiper styles
+import { Navigation } from "swiper";
 import "swiper/css";
 import "swiper/css/pagination";
 import "swiper/css/navigation";
-
-// import required modules
-import { Navigation } from "swiper";
 
 export default function Carousel() {
     const url = "http://ec2-43-201-14-234.ap-northeast-2.compute.amazonaws.com:8080";
@@ -88,18 +85,8 @@ const Container = styled.div`
         height: 100%;
     }
 
-    /* .swiper-container {
-        width: 100%;
-        height: 400px;
-        padding: 0 50px;
-    } */
-
     .swiper-slide {
         font-size: 18px;
-        /* height: 150px; */
-        /* height: 320px; */
-
-        /* Center slide text vertically */
         display: -webkit-box;
         display: -ms-flexbox;
         display: -webkit-flex;
@@ -128,7 +115,6 @@ const Container = styled.div`
         background-repeat: no-repeat;
         background-size: 100% auto;
         background-position: center;
-        /* left: -30px; */
     }
 
     .swiper-button-next {
@@ -138,7 +124,6 @@ const Container = styled.div`
         background-repeat: no-repeat;
         background-size: 100% auto;
         background-position: center;
-        /* right: -30px; */
     }
 
     .swiper-button-next::after,
@@ -154,14 +139,4 @@ const Container = styled.div`
         padding-left: 50px;
         padding-right: 50px;
     }
-
-    /* .swiper-pagination {
-        position: absolute;
-        /* bottom: -10px !important; 
-    }
-
-    .swiper-pagination-bullet {
-        background-color: var(--green);
-        margin: 0 10px !important;
-    } */
 `;

--- a/client/src/components/main/Preview.js
+++ b/client/src/components/main/Preview.js
@@ -116,6 +116,7 @@ const Post = styled.div`
         }
     }
     button {
+        font-family: "Nanum Gothic", sans-serif;
         width: 100%;
     }
 `;

--- a/client/src/components/mypage/MyPageEdit.js
+++ b/client/src/components/mypage/MyPageEdit.js
@@ -56,7 +56,6 @@ const MyPageEdit = ({ name, email }) => {
             },
         })
             .then((res) => {
-                console.log(res);
                 openModalHandler();
             })
             .catch((error) => {
@@ -82,7 +81,6 @@ const MyPageEdit = ({ name, email }) => {
 
     const openModalHandler = () => {
         if (editUser.password === editUser.checkPW && editUser.nickName !== "" && editUser.nickName.length >= 2 && checkPWPattern(editUser.password)) {
-            console.log("변경됨");
             setIsOpen(!isOpen);
         }
     };

--- a/client/src/components/mypage/UserPost.js
+++ b/client/src/components/mypage/UserPost.js
@@ -98,7 +98,6 @@ const Post = styled.div`
         }
         @media screen and (max-width: 619px) {
             font-size: 12px;
-            /* height: 90px; */
         }
         @media screen and (max-width: 576px) {
             display: none;
@@ -116,10 +115,6 @@ const Post = styled.div`
         @media screen and (max-width: 576px) {
             padding-top: 53px;
         }
-
-        /* @media screen and (max-width: 535px) {
-            padding-top: 25px;
-        } */
 
         @media screen and (max-width: 503px) {
             display: none;

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -32,6 +32,12 @@ const Main = ({ setIsFooter }) => {
                     <div className="text">
                         <p className="description">심리적인 괴로움, 감정을 탈탈 털어놓으세요.</p>
                         <p className="logo">MENTALTAL</p>
+                        <Link to="/">
+                            <button>
+                                서비스 소개
+                                <i className="fa-solid fa-chevron-right" />
+                            </button>
+                        </Link>
                     </div>
                 </Intro>
                 <PreviewContainer>
@@ -101,7 +107,7 @@ const Intro = styled.div`
     }
 
     .text {
-        padding-top: 200px;
+        padding-top: 190px;
         padding-left: 90px;
         color: var(--white);
 
@@ -111,8 +117,25 @@ const Intro = styled.div`
 
         .logo {
             font-size: 55px;
-            padding-top: 10px;
+            padding-top: 12px;
             font-weight: var(--font-bold);
+        }
+        button {
+            margin-top: 23px;
+            background-color: var(--white);
+            color: var(--green);
+            font-family: "Nanum Gothic", sans-serif;
+            font-weight: var(--font-bold);
+            border-radius: 50px;
+            padding: 3% 7%;
+
+            i {
+                margin-left: 10px;
+            }
+            :hover {
+                background-color: var(--lightgreen);
+                color: var(--white);
+            }
         }
     }
 `;

--- a/client/src/pages/Main.js
+++ b/client/src/pages/Main.js
@@ -111,17 +111,31 @@ const Intro = styled.div`
         padding-left: 90px;
         color: var(--white);
 
+        @media screen and (max-width: 414px) {
+            padding-left: 50px;
+        }
+
         .description {
             font-size: 18px;
+
+            @media screen and (max-width: 414px) {
+                font-size: 15px;
+                transition: 0.5s;
+            }
         }
 
         .logo {
             font-size: 55px;
             padding-top: 12px;
             font-weight: var(--font-bold);
+
+            @media screen and (max-width: 414px) {
+                font-size: 50px;
+                transition: 0.5s;
+            }
         }
         button {
-            margin-top: 23px;
+            margin-top: 25px;
             background-color: var(--white);
             color: var(--green);
             font-family: "Nanum Gothic", sans-serif;
@@ -136,6 +150,11 @@ const Intro = styled.div`
                 background-color: var(--lightgreen);
                 color: var(--white);
             }
+
+            @media screen and (max-width: 414px) {
+                font-size: 12px;
+                transition: 0.5s;
+            }
         }
     }
 `;
@@ -143,6 +162,10 @@ const Intro = styled.div`
 const PreviewContainer = styled.div`
     padding: 0 90px;
     padding-top: 90px;
+
+    @media screen and (max-width: 414px) {
+        padding: 90px 50px;
+    }
 
     .text {
         font-size: 18px;
@@ -160,6 +183,10 @@ const PreviewContainer = styled.div`
 const Shortcut = styled.div`
     padding: 0 90px;
     padding-top: 90px;
+
+    @media screen and (max-width: 414px) {
+        padding: 0 50px;
+    }
 
     .text {
         font-size: 18px;

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -8,7 +8,7 @@ import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 
 const MyPage = ({ setIsFooter }) => {
-    const token = localStorage.getItem("loginToken"); // 토큰 존재할 경우에만 마이페이지 진입 가능
+    const token = localStorage.getItem("loginToken");
     const { id } = useParams();
     const [userData, setUserData] = useState(undefined);
     const url = "http://ec2-43-201-14-234.ap-northeast-2.compute.amazonaws.com:8080";
@@ -70,7 +70,6 @@ const MyPage = ({ setIsFooter }) => {
             },
         })
             .then((res) => {
-                console.log(`${id}번 유저가 삭제됨`);
                 localStorage.removeItem("loginToken");
                 navigate("/");
                 window.location.reload();
@@ -282,7 +281,6 @@ const ModalBackdrop = styled.div`
 `;
 
 const ModalView = styled.div.attrs((props) => ({
-    // attrs 메소드를 이용해서 아래와 같이 div 엘리먼트에 속성을 추가할 수 있습니다.
     role: "dialog",
 }))`
     background-color: whitesmoke;


### PR DESCRIPTION
## 개요
메인 페이지 UI 조정
전문가 페이지 UI 조정
## 작업사항
- 메인 페이지 헤더에 소개 페이지로 이동하는 버튼 추가
- 300px단위 작은 화면에도 어색하지 않게 메인 페이지 반응형 UI 재조정
- 전문가 페이지 폰트 적용
- 전문가 페이지 헤더 텍스트 위치 조정, 행간 조정, 안내 문구 내용 수정
## 변경사항 (존재한다면)
- [CounselorHeader.js]
## 기타