### PR TITLE
[refactor] 토큰 받아오는 방식 localStorage -> sessionStorage로 변경

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -7,12 +7,12 @@ import NavModal from "./NavModal";
 
 const Nav = () => {
     const memberId = useRecoilValue(memberIdState); // 마이페이지 path
-    const token = localStorage.getItem("loginToken");
+    const token = sessionStorage.getItem("loginToken");
 
     // 로그아웃 버튼 핸들러
     const logoutBtnHandle = () => {
-        localStorage.removeItem("memberId");
-        localStorage.removeItem("loginToken");
+        sessionStorage.removeItem("memberId");
+        sessionStorage.removeItem("loginToken");
         window.location.reload();
     };
 

--- a/client/src/components/NavModal.js
+++ b/client/src/components/NavModal.js
@@ -3,12 +3,12 @@ import { Link } from "react-router-dom";
 import { useState } from "react";
 
 const NavModal = ({ memberId, setIsActive, isActive }) => {
-    const token = localStorage.getItem("loginToken");
+    const token = sessionStorage.getItem("loginToken");
 
     // 로그아웃 버튼 핸들러
     const logoutBtnHandle = () => {
-        localStorage.removeItem("memberId");
-        localStorage.removeItem("loginToken");
+        sessionStorage.removeItem("memberId");
+        sessionStorage.removeItem("loginToken");
         window.location.reload();
     };
 

--- a/client/src/components/boards/BoardDetailAnswer.js
+++ b/client/src/components/boards/BoardDetailAnswer.js
@@ -10,7 +10,7 @@ const BoardDetailAnswer = ({ answer, setIsLogin, idx }) => {
     const url = process.env.REACT_APP_SERVER_URL;
     const [isEdit, setIsEdit] = useState(false);
     const memberId = useRecoilValue(memberIdState);
-    const token = localStorage.getItem("loginToken");
+    const token = sessionStorage.getItem("loginToken");
 
     // 랜덤 사진
     const unsplashId = process.env.REACT_APP_UNSPLASH_KEY;

--- a/client/src/components/boards/BoardDetailAnswerCreate.js
+++ b/client/src/components/boards/BoardDetailAnswerCreate.js
@@ -8,7 +8,7 @@ const BoardDetailAnswerCreate = ({ setIsLogin }) => {
     const url = process.env.REACT_APP_SERVER_URL;
     const board = useRecoilValue(boardState);
     const memberId = useRecoilValue(memberIdState);
-    const token = localStorage.getItem("loginToken");
+    const token = sessionStorage.getItem("loginToken");
 
     // 답글 등록 form
     const {

--- a/client/src/components/boards/BoardDetailQuestion.js
+++ b/client/src/components/boards/BoardDetailQuestion.js
@@ -11,7 +11,7 @@ const BoardDetailQuestion = ({ setIsLogin }) => {
     const navigate = useNavigate();
     const [board, setBoard] = useRecoilState(boardState);
     const memberId = useRecoilValue(memberIdState);
-    const token = localStorage.getItem("loginToken");
+    const token = sessionStorage.getItem("loginToken");
     const imgUrl = useRecoilValue(questionImgState);
 
     // 질문 삭제

--- a/client/src/components/boards/CreateBoardMain.js
+++ b/client/src/components/boards/CreateBoardMain.js
@@ -8,7 +8,7 @@ import { memberIdState } from "../../states/";
 
 const CreateBoardMain = ({ setIsLogin }) => {
     const url = process.env.REACT_APP_SERVER_URL;
-    const token = localStorage.getItem("loginToken");
+    const token = sessionStorage.getItem("loginToken");
 
     const {
         register,

--- a/client/src/components/mypage/MyPageEdit.js
+++ b/client/src/components/mypage/MyPageEdit.js
@@ -48,7 +48,7 @@ const MyPageEdit = ({ name, email }) => {
             method: "patch",
             url: `${url}/members/${id}`,
             headers: {
-                Authorization: localStorage.getItem("loginToken"),
+                Authorization: sessionStorage.getItem("loginToken"),
             },
             data: {
                 nickName: nickName,

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -32,9 +32,9 @@ const Login = ({ setIsFooter }) => {
         axios
             .post(`${url}/members/login`, data)
             .then((res) => {
-                localStorage.setItem("loginToken", res.headers.authorization);
+                sessionStorage.setItem("loginToken", res.headers.authorization);
 
-                if (localStorage.getItem("loginToken") !== "undefined") {
+                if (sessionStorage.getItem("loginToken") !== "undefined") {
                     setMemberId(res.data.memberId);
                     navigate("/main");
                 } else {

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -8,7 +8,7 @@ import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 
 const MyPage = ({ setIsFooter }) => {
-    const token = localStorage.getItem("loginToken");
+    const token = sessionStorage.getItem("loginToken");
     const { id } = useParams();
     const [userData, setUserData] = useState(undefined);
     const url = process.env.REACT_APP_SERVER_URL;
@@ -66,11 +66,11 @@ const MyPage = ({ setIsFooter }) => {
             method: "delete",
             url: `${url}/members/${id}`,
             headers: {
-                Authorization: localStorage.getItem("loginToken"),
+                Authorization: sessionStorage.getItem("loginToken"),
             },
         })
             .then((res) => {
-                localStorage.removeItem("loginToken");
+                sessionStorage.removeItem("loginToken");
                 navigate("/");
                 window.location.reload();
             })


### PR DESCRIPTION
## 개요
localStorage -> sessionStorage로 변경
## 작업사항
서버를 닫고 다시 열었을 때 이전 로그인 토큰이 localStorage에 남아 있어, 이전 로그인한 회원 정보로 보이는 오류가 생겨 sessionStorage로 저장하는 방식으로 변경하여 해결
## 변경사항 (존재한다면)
- client/src/components/Nav.js
- client/src/components/NavModal.js
- client/src/components/boards/BoardDetailAnswer.js
- client/src/components/boards/BoardDetailAnswerCreate.js
- client/src/components/boards/BoardDetailQuestion.js
- client/src/components/boards/CreateBoardMain.js
- client/src/components/mypage/MyPageEdit.js
- client/src/pages/Login.js
- client/src/pages/MyPage.js
## 기타